### PR TITLE
Refactors Error Service Injection for Scoped Access

### DIFF
--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.Files.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.Files.cs
@@ -1,4 +1,5 @@
 ﻿using DataGateVPNBot.Services.BotServices.Interfaces;
+using DataGateVPNBot.Services.Interfaces;
 using Telegram.Bot;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
@@ -179,6 +180,8 @@ public partial class TelegramUpdateHandler
         }
         catch(Exception ex)
         {
+            using var scope = serviceProvider.CreateScope();
+            var errorService = scope.ServiceProvider.GetRequiredService<IErrorService>();
             await errorService.NotifyAdminsAboutExceptionAsync(ex, null, cancellationToken);
             return await _botClient.SendMessage(
                 msg.Chat,
@@ -236,6 +239,8 @@ public partial class TelegramUpdateHandler
         }
         catch(Exception ex)
         {
+            using var scope = serviceProvider.CreateScope();
+            var errorService = scope.ServiceProvider.GetRequiredService<IErrorService>();
             await errorService.NotifyAdminsAboutExceptionAsync(ex, null, cancellationToken);
             return await _botClient.SendMessage(
                 msg.Chat,

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
@@ -21,8 +21,7 @@ public partial class TelegramUpdateHandler(
     IServiceProvider serviceProvider,
     ITelegramSettingsService telegramSettingsService,
     AuthService authService,
-    BotConfiguration botConfig,
-    IErrorService errorService)
+    BotConfiguration botConfig)
     : IUpdateHandler
 {
     private readonly ILogger<TelegramUpdateHandler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -38,6 +37,7 @@ public partial class TelegramUpdateHandler(
         _logger.LogCritical("HandleError: {Exception}", exception);
         using var scope = _serviceProvider.CreateScope();
 
+        var errorService = scope.ServiceProvider.GetRequiredService<IErrorService>();
         errorService.LogErrorToDatabase(exception);//todo:fix it
         await errorService.NotifyAdminsAboutExceptionAsync(exception, null, cancellationToken);
         if (exception is RequestException)

--- a/DataGateVPNBot/Program.cs
+++ b/DataGateVPNBot/Program.cs
@@ -14,6 +14,12 @@ builder.Services.ConfigureServices();
 builder.Services.ConfigureDashboardApi();
 
 builder.ConfigureWebHost(logger);
+builder.Host.UseDefaultServiceProvider(options =>
+{
+    options.ValidateScopes = true;
+    options.ValidateOnBuild = true;
+});
+
 
 var app = builder.Build();
 

--- a/DataGateVPNBot/Services/DashboardServices/ServerService.cs
+++ b/DataGateVPNBot/Services/DashboardServices/ServerService.cs
@@ -5,26 +5,16 @@ using OpenVPNGateMonitor.SharedModels.Responses;
 
 namespace DataGateVPNBot.Services.DashboardServices;
 
-public class ServerService
+public class ServerService(
+    ILogger<ServerService> logger,
+    IHttpRequestService httpRequestService,
+    AuthService authService)
 {
-    private readonly ILogger<ServerService> _logger;
-    private readonly IHttpRequestService _httpRequestService;
-    private readonly AuthService _authService;
     private const string EndpointGetAllOpenVpnFiles = "api/OpenVpnServers/GetAllServers";
-    
-    public ServerService(ILogger<ServerService> logger,
-        IHttpRequestService httpRequestService,
-        AuthService authService
-        )
-    {
-        _logger = logger;
-        _httpRequestService = httpRequestService;
-        _authService = authService;
-    }
 
     public async Task<List<OpenVpnServerResponse>?> GetOpenVpnServersListAsync(CancellationToken cancellationToken)
     {
-        var token = await _authService.GetTokenAsync();
+        var token = await authService.GetTokenAsync();
         var servers = new List<OpenVpnServerResponse>();
         if (string.IsNullOrEmpty(token))
         {
@@ -33,7 +23,7 @@ public class ServerService
 
         var url = $"{EndpointGetAllOpenVpnFiles}";
         
-        var response = await _httpRequestService.GetAsync<ApiResponse<List<OpenVpnServerResponse>>>(url, token, cancellationToken);
+        var response = await httpRequestService.GetAsync<ApiResponse<List<OpenVpnServerResponse>>>(url, token, cancellationToken);
 
         if (response is { Success: true, Data: not null })
         {
@@ -41,12 +31,12 @@ public class ServerService
         }
         else
         {
-            _logger.LogWarning($"Failed to get VPN servers: {response?.Message}");
+            logger.LogWarning($"Failed to get VPN servers: {response?.Message}");
         }
 
         if (response == null)
         {
-            _logger.LogError("Failed to fetch Open VPN Servers from API.");
+            logger.LogError("Failed to fetch Open VPN Servers from API.");
         }
 
         return servers;

--- a/DataGateVPNBot/Services/Http/HttpRequestService.cs
+++ b/DataGateVPNBot/Services/Http/HttpRequestService.cs
@@ -7,7 +7,7 @@ namespace DataGateVPNBot.Services.Http;
 
 public class HttpRequestService(
     IHttpClientFactoryService httpClientFactoryService,
-    IErrorService errorService,
+    IServiceProvider serviceProvider,
     ILogger<HttpRequestService> logger)
     : IHttpRequestService
 {
@@ -95,6 +95,8 @@ public class HttpRequestService(
     private async Task<T?> SendRequestAsync<T>(Func<Task<HttpResponseMessage>> httpRequest, string url,
         CancellationToken cancellationToken)
     {
+        using var scope = serviceProvider.CreateScope();
+        var errorService = scope.ServiceProvider.GetRequiredService<IErrorService>();
         var errorDetails = new StringBuilder();
         errorDetails.AppendLine($"Failed to complete HTTP request to {url} after 3 attempts.");
 

--- a/DataGateVPNBot/Services/TelegramApi/OpensslCertificateGenerator.cs
+++ b/DataGateVPNBot/Services/TelegramApi/OpensslCertificateGenerator.cs
@@ -5,10 +5,12 @@ using DataGateVPNBot.Services.Interfaces;
 namespace DataGateVPNBot.Services.TelegramApi;
 
 public class OpensslCertificateGenerator(ILogger<OpensslCertificateGenerator> logger, BotConfiguration config, 
-    IErrorService  errorService)
+    IServiceProvider serviceProvider)
 {
     public async Task EnsureCertificateAsync(string hostAddress, CancellationToken cancellationToken)
     {
+        using var scope = serviceProvider.CreateScope();
+        var errorService = scope.ServiceProvider.GetRequiredService<IErrorService>();
         await errorService.SendMessageToAdminsAsync("🔐 Verifying certificate...", cancellationToken);
 
         var certPath = !string.IsNullOrEmpty(config.CertificatePfxPath)


### PR DESCRIPTION
- Ensures `IErrorService` is accessed within a scope, preventing potential lifetime issues and promoting proper service disposal.
- Removes direct injection of `IErrorService` in `TelegramUpdateHandler` and `HttpRequestService` constructors to enforce scoped access.
- Improves the reliability and maintainability of error handling by using service scopes.