### PR TITLE
fix(bot): send XRay client links as text and stabilize startup port check

### DIFF
--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -6,8 +6,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <ApplicationIcon>logo/logo.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.3.4</AssemblyVersion>
-        <FileVersion>1.2.3.4</FileVersion>
+        <AssemblyVersion>1.2.3.5</AssemblyVersion>
+        <FileVersion>1.2.3.5</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DataGateVPNBot/Handlers/StartupBackgroundService.cs
+++ b/DataGateVPNBot/Handlers/StartupBackgroundService.cs
@@ -221,17 +221,18 @@ public class StartupBackgroundService(
 
     private static int GetHealthCheckPort()
     {
-        // Docker / production: Kestrel often listens on TELEGRAMBOT_PORT (e.g. 5583), not 80.
-        if (int.TryParse(Environment.GetEnvironmentVariable("TELEGRAMBOT_PORT"), out var telegramBotPort) &&
-            telegramBotPort > 0)
-            return telegramBotPort;
-
         if (bool.TryParse(Environment.GetEnvironmentVariable("USE_CERTIFICATE"), out var useCert) && !useCert)
         {
             if (int.TryParse(Environment.GetEnvironmentVariable("TELEGRAMBOT_LISTEN_PORT"), out var port) && port > 0)
                 return port;
             return 5050;
         }
+
+        // In certificate mode, prefer externally configured bot port.
+        if (int.TryParse(Environment.GetEnvironmentVariable("TELEGRAMBOT_PORT"), out var telegramBotPort) &&
+            telegramBotPort > 0)
+            return telegramBotPort;
+
         return 80;
     }
 }

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.Files.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.Files.cs
@@ -127,6 +127,27 @@ public partial class TelegramUpdateHandler
         _logger.LogInformation($"GetMyFiles started for user: {msg.Chat.Id}, ServerId: {vpnServerId}");
 
         var isXray = await IsXrayServerAsync(scope, vpnServerId, cancellationToken);
+        if (isXray)
+        {
+            var text = await scope.ServiceProvider.GetRequiredService<IXrayClientLinkBotService>()
+                .GetClientLinksTextWithTokenAsync(vpnServerId, msg.Chat.Id, cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return await _botClient.SendMessage(
+                    chatId: msg.Chat.Id,
+                    text: await GetLocalizationTextAsync("FilesNotFoundError", msg.Chat.Id, cancellationToken),
+                    replyMarkup: new ReplyKeyboardRemove(),
+                    cancellationToken: cancellationToken);
+            }
+
+            return await _botClient.SendMessage(
+                chatId: msg.Chat.Id,
+                text: text,
+                replyMarkup: new ReplyKeyboardRemove(),
+                cancellationToken: cancellationToken);
+        }
+
         var mediaGroupOpenVpnFiles = isXray
             ? await scope.ServiceProvider.GetRequiredService<IXrayClientLinkBotService>()
                 .GetOvpnFilesWithTokenAsync(vpnServerId, msg.Chat.Id, _botConfig.HostAddress, cancellationToken)
@@ -251,6 +272,28 @@ public partial class TelegramUpdateHandler
                 : await scope.ServiceProvider.GetRequiredService<IOvpnFileService>()
                     .MakeOvpnFileWithTokenAsync(vpnServerId, msg.Chat.Id, _botConfig.HostAddress,
                         cancellationToken);
+
+            if (isXray)
+            {
+                var text = await scope.ServiceProvider.GetRequiredService<IXrayClientLinkBotService>()
+                    .MakeClientLinkTextWithTokenAsync(vpnServerId, msg.Chat.Id, cancellationToken);
+
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    return await _botClient.SendMessage(
+                        chatId: msg.Chat.Id,
+                        text: await GetLocalizationTextAsync("FilesNotFoundError", msg.Chat.Id, cancellationToken),
+                        replyMarkup: new ReplyKeyboardRemove(),
+                        cancellationToken: cancellationToken);
+                }
+
+                return await _botClient.SendMessage(
+                    chatId: msg.Chat.Id,
+                    text: text,
+                    replyMarkup: new ReplyKeyboardRemove(),
+                    cancellationToken: cancellationToken);
+            }
+
             if (!mediaGroupOpenVpnFiles.Any())
             {
                 return await _botClient.SendMessage(

--- a/DataGateVPNBot/Services/BotServices/Interfaces/IXrayClientLinkBotService.cs
+++ b/DataGateVPNBot/Services/BotServices/Interfaces/IXrayClientLinkBotService.cs
@@ -16,9 +16,13 @@ public interface IXrayClientLinkBotService
         CancellationToken cancellationToken);
     Task<List<IAlbumInputMedia>> GetOvpnFilesWithTokenAsync(int vpnServerId, long telegramId, string hostUrl,
         CancellationToken cancellationToken);
+    Task<string> GetClientLinksTextWithTokenAsync(int vpnServerId, long telegramId,
+        CancellationToken cancellationToken);
     Task<List<IAlbumInputMedia>> MakeOvpnFileAsync(int vpnServerId, long telegramId,
         CancellationToken cancellationToken);
     Task<List<IAlbumInputMedia>> MakeOvpnFileWithTokenAsync(int vpnServerId, long telegramId, string hostUrl,
+        CancellationToken cancellationToken);
+    Task<string> MakeClientLinkTextWithTokenAsync(int vpnServerId, long telegramId,
         CancellationToken cancellationToken);
     Task<bool> RevokeAllOvpnFileAsync(int vpnServerId, long telegramId, CancellationToken cancellationToken);
     Task<bool> RevokeOvpnFileAsync(int vpnServerId, long telegramId, string fileName, CancellationToken cancellationToken);

--- a/DataGateVPNBot/Services/BotServices/XrayClientLinkBotService.cs
+++ b/DataGateVPNBot/Services/BotServices/XrayClientLinkBotService.cs
@@ -228,6 +228,54 @@ public class XrayClientLinkBotService(XrayClientLinksDashboardService ovpnFileSe
         return mediaGroupOpenVpnFiles;
     }
 
+    public async Task<string> GetClientLinksTextWithTokenAsync(int vpnServerId, long telegramId,
+        CancellationToken cancellationToken)
+    {
+        var request = new ByExternalIdAndVpnServerIdRequest
+        {
+            VpnServerId = vpnServerId,
+            ExternalId = telegramId.ToString()
+        };
+
+        var response = await ovpnFileService.GetAllOvpnFilesByExternalIdWithTokenAsync(request, cancellationToken);
+        if (response == null || !response.IssuedOvpnFiles.Any())
+            return string.Empty;
+
+        var activeFiles = response.IssuedOvpnFiles.Where(x => !x.IsRevoked).ToList();
+        if (!activeFiles.Any())
+            return string.Empty;
+
+        var sb = new StringBuilder();
+        foreach (var file in activeFiles)
+        {
+            try
+            {
+                var download = await ovpnFileService.DownloadOvpnFileByIdAndServerIdAsync(new DownloadFileRequest
+                {
+                    VpnServerId = file.VpnServerId,
+                    IssuedOvpnFileId = file.Id
+                }, cancellationToken);
+
+                var text = Encoding.UTF8.GetString(download.Content ?? Array.Empty<byte>()).Trim();
+                if (string.IsNullOrWhiteSpace(text))
+                    continue;
+
+                if (sb.Length > 0)
+                    sb.AppendLine().AppendLine("-----").AppendLine();
+
+                sb.AppendLine(file.FileName);
+                sb.AppendLine(text);
+            }
+            catch (Exception ex)
+            {
+                await errorService.NotifyAdminsAboutExceptionAsync(ex, null, cancellationToken);
+                logger.LogError(ex, "Failed to prepare XRay text link for file {FileName}", file.FileName);
+            }
+        }
+
+        return sb.ToString().Trim();
+    }
+
 
     public async Task<List<IAlbumInputMedia>> MakeOvpnFileWithTokenAsync(int vpnServerId, long telegramId, 
         string hostUrl, CancellationToken cancellationToken)
@@ -308,6 +356,37 @@ public class XrayClientLinkBotService(XrayClientLinksDashboardService ovpnFileSe
         }
 
         return mediaGroupOpenVpnFiles;
+    }
+
+    public async Task<string> MakeClientLinkTextWithTokenAsync(int vpnServerId, long telegramId,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Creating XRay client link text. TelegramId: {TelegramId}, ServerId: {VpnServerId}",
+            telegramId, vpnServerId);
+
+        var addRequest = new AddFileRequest
+        {
+            VpnServerId = vpnServerId,
+            CommonName = await MakeCommonNameForOvpnFileAsync(vpnServerId, telegramId, cancellationToken),
+            ExternalId = telegramId.ToString(),
+            IssuedTo = $"telegram user {telegramId} with token"
+        };
+
+        var created = await ovpnFileService.AddOvpnFileWithTokenAsync(addRequest, cancellationToken);
+        if (created?.IssuedOvpnFile == null)
+            return string.Empty;
+
+        var download = await ovpnFileService.DownloadOvpnFileByIdAndServerIdAsync(new DownloadFileRequest
+        {
+            VpnServerId = created.IssuedOvpnFile.VpnServerId,
+            IssuedOvpnFileId = created.IssuedOvpnFile.Id
+        }, cancellationToken);
+
+        var text = Encoding.UTF8.GetString(download.Content ?? Array.Empty<byte>()).Trim();
+        if (string.IsNullOrWhiteSpace(text))
+            return string.Empty;
+
+        return $"{created.IssuedOvpnFile.FileName}{Environment.NewLine}{text}";
     }
 
 


### PR DESCRIPTION
Avoid invalid tokenized OpenVPN downloads for XRay by returning link content as plain text messages, and make startup health checks use the internal listen port in non-certificate mode. Also bump bot version to 1.2.3.5 for release packaging.

Made-with: Cursor
