### PR TITLE
Adds profile photo sync and filters disabled VPN servers

### DIFF
--- a/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
+++ b/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <!-- SharedModels: NuGet only (never ProjectReference). -->
-    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.11" />
+    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.13" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataGateVPNBot\DataGateVPNBot.csproj" />

--- a/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
+++ b/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <!-- SharedModels: NuGet only (never ProjectReference). -->
-    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.8" />
+    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataGateVPNBot\DataGateVPNBot.csproj" />

--- a/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
+++ b/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <!-- SharedModels: NuGet only (never ProjectReference). -->
-    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.13" />
+    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.14" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataGateVPNBot\DataGateVPNBot.csproj" />

--- a/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
+++ b/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <!-- SharedModels: NuGet only (never ProjectReference). -->
-    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.10" />
+    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataGateVPNBot\DataGateVPNBot.csproj" />

--- a/DataGateVPNBot/Configurations/ServiceConfiguration.cs
+++ b/DataGateVPNBot/Configurations/ServiceConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using Certes;
+using Microsoft.Extensions.Configuration;
 using DataGateVPNBot.Handlers;
 using DataGateVPNBot.Services;
 using DataGateVPNBot.Services.BotServices;
@@ -14,12 +15,16 @@ namespace DataGateVPNBot.Configurations;
 
 public static class ServiceConfiguration
 {
-    public static void ConfigureServices(this IServiceCollection services)
+    public static void ConfigureServices(this IServiceCollection services, IConfiguration configuration)
     {
+        services.Configure<DataGateVPNBot.Models.Configurations.ProfilePhotoRefreshOptions>(
+            configuration.GetSection(DataGateVPNBot.Models.Configurations.ProfilePhotoRefreshOptions.SectionName));
         services.AddSingleton<IKey>(_ => LetsEncryptAccountStore.LoadOrCreateAccountKey());
         
         services.AddScoped<IIncomingMessageLogService, IncomingMessageLogService>();
         services.AddScoped<ITelegramBotUserService, TelegramBotUserService>();
+        services.AddScoped<ITelegramUserProfilePhotoRefreshService, TelegramUserProfilePhotoRefreshService>();
+        services.AddHostedService<MonthlyProfilePhotoRefreshHostedService>();
         services.AddScoped<ILocalizationService, LocalizationService>();
         services.AddScoped<IIncomingMessageLogSenderService, IncomingMessageLogSenderService>();
         services.AddScoped<IErrorService, ErrorService>();

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <!-- SharedModels: NuGet only (never ProjectReference). Bump after publishing a new package version. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.11" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.13" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -6,8 +6,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <ApplicationIcon>logo/logo.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.3.10</AssemblyVersion>
-        <FileVersion>1.2.3.10</FileVersion>
+        <AssemblyVersion>1.2.3.11</AssemblyVersion>
+        <FileVersion>1.2.3.11</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -21,7 +21,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <!-- SharedModels: NuGet only (never ProjectReference). Bump after publishing a new package version. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.10" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.11" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <!-- SharedModels: NuGet only (never ProjectReference). Bump after publishing a new package version. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.13" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.14" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <!-- SharedModels: NuGet only (never ProjectReference). Bump after publishing a new package version. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.8" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.10" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -6,8 +6,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <ApplicationIcon>logo/logo.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.3.9</AssemblyVersion>
-        <FileVersion>1.2.3.9</FileVersion>
+        <AssemblyVersion>1.2.3.10</AssemblyVersion>
+        <FileVersion>1.2.3.10</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DataGateVPNBot/Handlers/BotCommands.cs
+++ b/DataGateVPNBot/Handlers/BotCommands.cs
@@ -32,4 +32,7 @@ public static class BotCommands
     public const string CommandPoll = "/poll";
     public const string CommandPollAnonymous = "/poll_anonymous";
     public const string CommandThrow = "/throw";
+
+    /// <summary>Admin only: push current Telegram profile photos into the dashboard for every registered user.</summary>
+    public const string CommandRefreshProfilePhotos = "/refresh_profile_photos";
 }

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.Files.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.Files.cs
@@ -1,4 +1,5 @@
-﻿using DataGateVPNBot.Services.BotServices.Interfaces;
+﻿using DataGateVPNBot.Helpers;
+using DataGateVPNBot.Services.BotServices.Interfaces;
 using DataGateVPNBot.Services.DashboardServices;
 using DataGateVPNBot.Services.Interfaces;
 using DataGateMonitor.SharedModels.Enums;
@@ -50,6 +51,9 @@ public partial class TelegramUpdateHandler
         var currentRow = new List<InlineKeyboardButton>();
         foreach (var server in serverResponses.VpnServers)
         {
+            if (VpnServerDtoReflection.IsDisabled(server))
+                continue;
+
             var label = server.ServerType == VpnServerType.Xray
                 ? $"{server.ServerName} (VLESS)"
                 : server.ServerName;

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.ProfilePhotos.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.ProfilePhotos.cs
@@ -1,0 +1,67 @@
+using DataGateVPNBot.Services.BotServices;
+using DataGateVPNBot.Services.BotServices.Interfaces;
+using DataGateVPNBot.Services.DashboardServices.Interfaces;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+
+namespace DataGateVPNBot.Handlers;
+
+public partial class TelegramUpdateHandler
+{
+    private async Task<Message> AdminRefreshAllProfilePhotosAsync(Message msg, CancellationToken cancellationToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var tgUserService = scope.ServiceProvider.GetRequiredService<ITelegramBotUserService>();
+        var refresh = scope.ServiceProvider.GetRequiredService<ITelegramUserProfilePhotoRefreshService>();
+
+        if (!await tgUserService.IsTelegramDashboardAdminAsync(msg.From!.Id, cancellationToken))
+        {
+            return await _botClient.SendMessage(
+                msg.Chat.Id,
+                "⛔ This command is only for bot administrators.",
+                cancellationToken: cancellationToken);
+        }
+
+        await _botClient.SendMessage(
+            msg.Chat.Id,
+            "⏳ Syncing profile photos for all registered users with the dashboard. This may take a while…",
+            cancellationToken: cancellationToken);
+
+        var result = await refresh.RefreshAllFromTelegramAsync(cancellationToken);
+        var text = FormatProfilePhotoRefreshReport(result);
+
+        if (text.Length > 4090)
+            text = text[..4090] + "…";
+
+        return await _botClient.SendMessage(
+            msg.Chat.Id,
+            text,
+            parseMode: ParseMode.Html,
+            cancellationToken: cancellationToken);
+    }
+
+    private static string FormatProfilePhotoRefreshReport(ProfilePhotoBatchRefreshResult r)
+    {
+        var lines = new List<string>
+        {
+            "<b>Profile photo sync</b>",
+            $"Users in DB: {r.TotalUsers}",
+            $"Avatars <b>updated</b> in DB: {r.Updated}",
+            $"Unchanged (same Telegram file): {r.Unchanged}",
+            $"No profile photo on Telegram: {r.SkippedNoProfilePhoto}",
+            $"No access (blocked bot / deleted / invalid id): {r.SkippedUserUnavailable}",
+            $"Failed (other): {r.Failed}"
+        };
+
+        if (r.Errors.Count > 0)
+        {
+            lines.Add("");
+            lines.Add("<b>Error samples</b>");
+            foreach (var e in r.Errors)
+                lines.Add(System.Net.WebUtility.HtmlEncode(e));
+        }
+
+        return string.Join("\n", lines);
+    }
+}

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
@@ -123,7 +123,8 @@ public partial class TelegramUpdateHandler(
             BotCommands.CommandMakeNewFileWithToken,
             BotCommands.CommandDeleteSelectedFile,
             BotCommands.CommandDeleteAllFiles,
-            BotCommands.CommandDashboardApiGetToken
+            BotCommands.CommandDashboardApiGetToken,
+            BotCommands.CommandRefreshProfilePhotos
         };
 
         if (!isPrivate && privateOnlyCommands.Contains(command))
@@ -166,6 +167,7 @@ public partial class TelegramUpdateHandler(
             BotCommands.CommandPoll => SendPoll(msg),
             BotCommands.CommandPollAnonymous => SendAnonymousPoll(msg),
             BotCommands.CommandThrow => FailingHandler(),
+            BotCommands.CommandRefreshProfilePhotos => AdminRefreshAllProfilePhotosAsync(msg, cancellationToken),
 
             _ => Usage(msg, cancellationToken)
         });

--- a/DataGateVPNBot/Helpers/VpnServerDtoReflection.cs
+++ b/DataGateVPNBot/Helpers/VpnServerDtoReflection.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+
+namespace DataGateVPNBot.Helpers;
+
+/// <summary>
+/// Reads <c>IsDisabled</c> from <see cref="DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto.VpnServerDto"/>
+/// when the installed SharedModels package includes that property (reflection keeps the bot buildable on older package versions).
+/// </summary>
+internal static class VpnServerDtoReflection
+{
+    public static bool IsDisabled(object? server)
+    {
+        if (server == null) return false;
+        var p = server.GetType().GetProperty("IsDisabled", BindingFlags.Public | BindingFlags.Instance);
+        return p?.PropertyType == typeof(bool) && p.GetValue(server) is true;
+    }
+}

--- a/DataGateVPNBot/Models/Configurations/ProfilePhotoRefreshOptions.cs
+++ b/DataGateVPNBot/Models/Configurations/ProfilePhotoRefreshOptions.cs
@@ -1,0 +1,15 @@
+namespace DataGateVPNBot.Models.Configurations;
+
+public sealed class ProfilePhotoRefreshOptions
+{
+    public const string SectionName = "ProfilePhotoRefresh";
+
+    /// <summary>When false, the periodic background refresh is not registered.</summary>
+    public bool PeriodicRefreshEnabled { get; set; } = true;
+
+    /// <summary>Interval between automatic refresh runs.</summary>
+    public int IntervalDays { get; set; } = 30;
+
+    /// <summary>Optional delay between Telegram API calls per user (rate limiting).</summary>
+    public int DelayMillisecondsBetweenUsers { get; set; } = 75;
+}

--- a/DataGateVPNBot/Program.cs
+++ b/DataGateVPNBot/Program.cs
@@ -10,7 +10,7 @@ var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "
 logger.Information($"Application version: {version};");
 
 builder.Services.ConfigureTelegram(builder.Configuration);
-builder.Services.ConfigureServices();
+builder.Services.ConfigureServices(builder.Configuration);
 builder.Services.ConfigureDashboardApi();
 
 builder.ConfigureWebHost(logger);

--- a/DataGateVPNBot/Services/BotServices/Interfaces/ITelegramUserProfilePhotoRefreshService.cs
+++ b/DataGateVPNBot/Services/BotServices/Interfaces/ITelegramUserProfilePhotoRefreshService.cs
@@ -1,0 +1,10 @@
+namespace DataGateVPNBot.Services.BotServices.Interfaces;
+
+public interface ITelegramUserProfilePhotoRefreshService
+{
+    /// <summary>
+    /// For every Telegram bot user in the dashboard DB, fetches the current profile photo from Telegram
+    /// and upserts it via <c>POST api/tgbot-users/profile-photo</c>.
+    /// </summary>
+    Task<ProfilePhotoBatchRefreshResult> RefreshAllFromTelegramAsync(CancellationToken cancellationToken);
+}

--- a/DataGateVPNBot/Services/BotServices/MonthlyProfilePhotoRefreshHostedService.cs
+++ b/DataGateVPNBot/Services/BotServices/MonthlyProfilePhotoRefreshHostedService.cs
@@ -1,0 +1,82 @@
+using DataGateVPNBot.Models.Configurations;
+using DataGateVPNBot.Services.BotServices.Interfaces;
+using DataGateVPNBot.Services.Interfaces;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace DataGateVPNBot.Services.BotServices;
+
+/// <summary>
+/// Periodically syncs Telegram profile photos into the dashboard DB and notifies admins when at least one avatar was updated.
+/// </summary>
+public sealed class MonthlyProfilePhotoRefreshHostedService(
+    IServiceProvider serviceProvider,
+    IOptions<ProfilePhotoRefreshOptions> options,
+    ILogger<MonthlyProfilePhotoRefreshHostedService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!options.Value.PeriodicRefreshEnabled)
+        {
+            logger.LogInformation("Periodic profile photo refresh is disabled (ProfilePhotoRefresh:PeriodicRefreshEnabled).");
+            return;
+        }
+
+        var days = Math.Clamp(options.Value.IntervalDays, 1, 365);
+        using var timer = new PeriodicTimer(TimeSpan.FromDays(days));
+
+        logger.LogInformation(
+            "Scheduled Telegram profile photo refresh every {Days} day(s). First run after this interval.",
+            days);
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken))
+                await RunOnceSafeAsync(stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // shutdown
+        }
+    }
+
+    private async Task RunOnceSafeAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            using var scope = serviceProvider.CreateScope();
+            var refresh = scope.ServiceProvider.GetRequiredService<ITelegramUserProfilePhotoRefreshService>();
+            var errorService = scope.ServiceProvider.GetRequiredService<IErrorService>();
+
+            var result = await refresh.RefreshAllFromTelegramAsync(stoppingToken);
+
+            if (!result.AnyDatabaseChange)
+            {
+                logger.LogInformation(
+                    "Periodic profile photo refresh finished: total={Total}, updated=0, unchanged={Unchanged}, noPhoto={NoPhoto}, unavailable={Unavailable}, failed={Failed}",
+                    result.TotalUsers, result.Unchanged, result.SkippedNoProfilePhoto, result.SkippedUserUnavailable,
+                    result.Failed);
+                return;
+            }
+
+            var msg =
+                "🖼 Scheduled profile photo sync\n" +
+                $"Users in DB: {result.TotalUsers}\n" +
+                $"Avatars updated in DB: {result.Updated}\n" +
+                $"Unchanged (same file id): {result.Unchanged}\n" +
+                $"No Telegram photo: {result.SkippedNoProfilePhoto}\n" +
+                $"No access (blocked bot / etc.): {result.SkippedUserUnavailable}\n" +
+                $"Failed (other): {result.Failed}\n" +
+                (result.Errors.Count > 0 ? "Samples:\n" + string.Join("\n", result.Errors) : "");
+
+            if (msg.Length > 4090)
+                msg = msg[..4090] + "…";
+
+            await errorService.SendMessageToAdminsAsync(msg, stoppingToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Periodic profile photo refresh failed.");
+        }
+    }
+}

--- a/DataGateVPNBot/Services/BotServices/ProfilePhotoBatchRefreshResult.cs
+++ b/DataGateVPNBot/Services/BotServices/ProfilePhotoBatchRefreshResult.cs
@@ -1,0 +1,19 @@
+namespace DataGateVPNBot.Services.BotServices;
+
+public sealed class ProfilePhotoBatchRefreshResult
+{
+    public int TotalUsers { get; init; }
+    public int Updated { get; init; }
+    public int Unchanged { get; init; }
+    public int SkippedNoProfilePhoto { get; init; }
+
+    /// <summary>
+    /// Telegram refused access (e.g. user blocked the bot, deleted account, invalid id) — expected, not a server bug.
+    /// </summary>
+    public int SkippedUserUnavailable { get; init; }
+
+    public int Failed { get; init; }
+    public IReadOnlyList<string> Errors { get; init; } = Array.Empty<string>();
+
+    public bool AnyDatabaseChange => Updated > 0;
+}

--- a/DataGateVPNBot/Services/BotServices/TelegramProfilePhotoAccessHelper.cs
+++ b/DataGateVPNBot/Services/BotServices/TelegramProfilePhotoAccessHelper.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using Telegram.Bot.Exceptions;
+
+namespace DataGateVPNBot.Services.BotServices;
+
+internal static class TelegramProfilePhotoAccessHelper
+{
+    /// <summary>
+    /// True when Telegram indicates we cannot talk to this user (blocked bot, deleted user, bad id, etc.).
+    /// </summary>
+    public static bool IsUserUnavailableForBot(Exception ex)
+    {
+        for (var e = ex; e is not null; e = e.InnerException)
+        {
+            if (e is ApiRequestException api && IsUserUnavailable(api))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsUserUnavailable(ApiRequestException ex)
+    {
+        if (ex.HttpStatusCode is HttpStatusCode.Forbidden or HttpStatusCode.NotFound)
+            return true;
+
+        var m = ex.Message ?? "";
+
+        // Telegram Bot API numeric error_code (often 403 when user blocked the bot)
+        if (ex.ErrorCode is 403 or 404)
+            return true;
+        if (ex.ErrorCode == 400 && m.Contains("USER_ID_INVALID", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return m.Contains("blocked by the user", StringComparison.OrdinalIgnoreCase)
+               || m.Contains("bot was blocked", StringComparison.OrdinalIgnoreCase)
+               || m.Contains("USER_IS_DELETED", StringComparison.OrdinalIgnoreCase)
+               || m.Contains("user is deactivated", StringComparison.OrdinalIgnoreCase)
+               || m.Contains("USER_ID_INVALID", StringComparison.OrdinalIgnoreCase)
+               || m.Contains("PEER_ID_INVALID", StringComparison.OrdinalIgnoreCase)
+               || m.Contains("CHAT_NOT_FOUND", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/DataGateVPNBot/Services/BotServices/TelegramSettingsService.cs
+++ b/DataGateVPNBot/Services/BotServices/TelegramSettingsService.cs
@@ -109,6 +109,16 @@ public class TelegramSettingsService : ITelegramSettingsService
                 ["ru"] = "Изменить язык",
                 ["el"] = "Αλλάξτε τη γλώσσα σας"
             }
+        },
+        new()
+        {
+            Command = BotCommands.CommandRefreshProfilePhotos,
+            Descriptions = new()
+            {
+                ["en"] = "Admin: sync all user profile photos to the dashboard",
+                ["ru"] = "Админ: обновить аватарки всех пользователей в панели",
+                ["el"] = "Διαχειριστής: συγχρονισμός φωτογραφιών προφίλ όλων των χρηστών"
+            }
         }
     ];
 

--- a/DataGateVPNBot/Services/BotServices/TelegramUserProfilePhotoRefreshService.cs
+++ b/DataGateVPNBot/Services/BotServices/TelegramUserProfilePhotoRefreshService.cs
@@ -1,0 +1,139 @@
+using DataGateVPNBot.Services.BotServices.Interfaces;
+using DataGateVPNBot.Services.DashboardServices.Interfaces;
+using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Responses.Dto;
+using Microsoft.Extensions.Options;
+using Telegram.Bot;
+using Telegram.Bot.Exceptions;
+using ProfilePhotoRefreshOptions = DataGateVPNBot.Models.Configurations.ProfilePhotoRefreshOptions;
+
+namespace DataGateVPNBot.Services.BotServices;
+
+public sealed class TelegramUserProfilePhotoRefreshService(
+    ILogger<TelegramUserProfilePhotoRefreshService> logger,
+    ITelegramBotClient botClient,
+    ITelegramBotUserService telegramBotUserService,
+    IOptions<ProfilePhotoRefreshOptions> options)
+    : ITelegramUserProfilePhotoRefreshService
+{
+    public async Task<ProfilePhotoBatchRefreshResult> RefreshAllFromTelegramAsync(
+        CancellationToken cancellationToken)
+    {
+        var delayMs = Math.Clamp(options.Value.DelayMillisecondsBetweenUsers, 0, 5000);
+
+        var data = await telegramBotUserService.GetAllTelegramUsersAsync(cancellationToken);
+        if (data is null)
+        {
+            logger.LogError("Refresh profile photos: could not load users from API.");
+            return new ProfilePhotoBatchRefreshResult
+            {
+                Errors = new[] { "Failed to load users from dashboard API." }
+            };
+        }
+
+        var users = data.TelegramBotUsers ?? new List<TelegramBotUserDto>();
+        var updated = 0;
+        var unchanged = 0;
+        var skipped = 0;
+        var skippedUnavailable = 0;
+        var failed = 0;
+        var errors = new List<string>();
+
+        foreach (var user in users)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (delayMs > 0)
+                await Task.Delay(delayMs, cancellationToken);
+
+            try
+            {
+                var photos = await botClient.GetUserProfilePhotos(user.TelegramId, offset: 0, limit: 1,
+                    cancellationToken);
+                if (photos.TotalCount == 0 || photos.Photos.Length == 0)
+                {
+                    skipped++;
+                    continue;
+                }
+
+                var sizes = photos.Photos[^1];
+                if (sizes.Length == 0)
+                {
+                    skipped++;
+                    continue;
+                }
+
+                var biggest = sizes[^1];
+                await using var ms = new MemoryStream();
+                await botClient.GetInfoAndDownloadFile(biggest.FileId, ms, cancellationToken);
+                var bytes = ms.ToArray();
+                if (bytes.Length == 0)
+                {
+                    skipped++;
+                    continue;
+                }
+
+                var request = new UpsertTelegramBotUserProfilePhotoRequest
+                {
+                    TelegramId = user.TelegramId,
+                    ProfilePhotoBase64 = Convert.ToBase64String(bytes),
+                    ProfilePhotoMimeType = "image/jpeg",
+                    ProfilePhotoFileUniqueId = string.IsNullOrEmpty(biggest.FileUniqueId) ? null : biggest.FileUniqueId
+                };
+
+                var upsert = await telegramBotUserService.UpsertProfilePhotoAsync(request, cancellationToken);
+                if (upsert is null)
+                {
+                    failed++;
+                    AppendError(errors, user.TelegramId, "API returned no data");
+                    continue;
+                }
+
+                if (upsert.Updated)
+                    updated++;
+                else
+                    unchanged++;
+            }
+            catch (Exception ex) when (TelegramProfilePhotoAccessHelper.IsUserUnavailableForBot(ex))
+            {
+                skippedUnavailable++;
+                logger.LogInformation(
+                    "Skip profile photo for TelegramId {Id}: user unavailable for bot ({Message})",
+                    user.TelegramId, ex.Message);
+            }
+            catch (ApiRequestException ex)
+            {
+                failed++;
+                AppendError(errors, user.TelegramId, ex.Message);
+                logger.LogWarning(ex, "Telegram API error for TelegramId {Id}", user.TelegramId);
+            }
+            catch (Exception ex)
+            {
+                failed++;
+                AppendError(errors, user.TelegramId, ex.Message);
+                logger.LogWarning(ex, "Refresh failed for TelegramId {Id}", user.TelegramId);
+            }
+        }
+
+        return new ProfilePhotoBatchRefreshResult
+        {
+            TotalUsers = users.Count,
+            Updated = updated,
+            Unchanged = unchanged,
+            SkippedNoProfilePhoto = skipped,
+            SkippedUserUnavailable = skippedUnavailable,
+            Failed = failed,
+            Errors = errors
+        };
+    }
+
+    private static void AppendError(List<string> errors, long telegramId, string message)
+    {
+        if (errors.Count >= 8)
+            return;
+        var line = $"{telegramId}: {message}";
+        if (line.Length > 220)
+            line = line[..217] + "...";
+        errors.Add(line);
+    }
+}

--- a/DataGateVPNBot/Services/DashboardServices/Interfaces/ITelegramBotUserService.cs
+++ b/DataGateVPNBot/Services/DashboardServices/Interfaces/ITelegramBotUserService.cs
@@ -1,3 +1,4 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Responses;
 using DataGateMonitor.SharedModels.DataGateMonitor.User.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.User.Responses;
@@ -10,4 +11,13 @@ public interface ITelegramBotUserService
         CancellationToken cancellationToken);
     Task<bool> UserExistsAsync(long telegramUserId, CancellationToken cancellationToken);
     Task<GetAdminsResponse> GetAdminsAsync(CancellationToken cancellationToken);
+
+    /// <summary>Returns true if <paramref name="telegramUserId"/> is among dashboard bot admins.</summary>
+    Task<bool> IsTelegramDashboardAdminAsync(long telegramUserId, CancellationToken cancellationToken);
+
+    Task<GetAllTelegramUsersResponse?> GetAllTelegramUsersAsync(CancellationToken cancellationToken);
+
+    Task<UpsertTelegramBotUserProfilePhotoResponse?> UpsertProfilePhotoAsync(
+        UpsertTelegramBotUserProfilePhotoRequest request,
+        CancellationToken cancellationToken);
 }

--- a/DataGateVPNBot/Services/DashboardServices/TelegramBotUserService.cs
+++ b/DataGateVPNBot/Services/DashboardServices/TelegramBotUserService.cs
@@ -2,6 +2,7 @@ using System.Security.Authentication;
 using DataGateVPNBot.Services.DashboardServices.Interfaces;
 using DataGateVPNBot.Services.Http;
 using DataGateVPNBot.Services.Interfaces;
+using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Responses;
 using DataGateMonitor.SharedModels.DataGateMonitor.User.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.User.Responses;
@@ -19,6 +20,8 @@ public class TelegramBotUserService(
     private const string EndpointRegisterUser = "api/users/register-from-tgbot";
     private const string EndpointGetAdmins = "api/tgbot-users/get-admins";
     private const string EndpointUserExists = "api/tgbot-users/check-exists";
+    private const string EndpointGetAll = "api/tgbot-users/get-all";
+    private const string EndpointProfilePhoto = "api/tgbot-users/profile-photo";
 
 
     public async Task<UsersResponse> RegisterUserAsync(RegisterUserFromTgBotRequest request, 
@@ -133,5 +136,61 @@ public class TelegramBotUserService(
         }
 
         return telegramBotAdmins;
+    }
+
+    public async Task<bool> IsTelegramDashboardAdminAsync(long telegramUserId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var admins = await GetAdminsAsync(cancellationToken);
+            return admins.TelegramBotAdmins?.Any(a => a.TelegramId == telegramUserId) == true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "IsTelegramDashboardAdminAsync failed for {TelegramUserId}", telegramUserId);
+            return false;
+        }
+    }
+
+    public async Task<GetAllTelegramUsersResponse?> GetAllTelegramUsersAsync(CancellationToken cancellationToken)
+    {
+        var token = await authService.GetTokenAsync();
+        if (string.IsNullOrEmpty(token))
+        {
+            logger.LogError("GetAllTelegramUsersAsync: Failed to obtain token.");
+            return null;
+        }
+
+        var response = await httpRequestService.GetAsync<ApiResponse<GetAllTelegramUsersResponse>>(
+            EndpointGetAll, token, cancellationToken);
+
+        if (response is { Success: true, Data: not null })
+            return response.Data;
+
+        logger.LogWarning("GetAllTelegramUsersAsync failed: {Message}", response?.Message);
+        return null;
+    }
+
+    public async Task<UpsertTelegramBotUserProfilePhotoResponse?> UpsertProfilePhotoAsync(
+        UpsertTelegramBotUserProfilePhotoRequest request,
+        CancellationToken cancellationToken)
+    {
+        var token = await authService.GetTokenAsync();
+        if (string.IsNullOrEmpty(token))
+        {
+            logger.LogError("UpsertProfilePhotoAsync: Failed to obtain token.");
+            return null;
+        }
+
+        var response = await httpRequestService.PostAsync<ApiResponse<UpsertTelegramBotUserProfilePhotoResponse>>(
+            EndpointProfilePhoto, request, token, cancellationToken);
+
+        if (response is { Success: true, Data: not null })
+            return response.Data;
+
+        logger.LogWarning("UpsertProfilePhotoAsync failed for TelegramId {Id}: {Message}", request.TelegramId,
+            response?.Message);
+        return null;
     }
 }


### PR DESCRIPTION
Enhances the bot with two primary features:

*   **Implements user profile photo synchronization:**
    *   Introduces an admin-only command (`/refresh_profile_photos`) to manually trigger an update of all registered users' Telegram profile photos to the dashboard.
    *   Adds a configurable background service for periodic, automatic refreshes of user profile photos, notifying administrators about any updates.
    *   Includes robust error handling, specifically addressing scenarios where users have blocked the bot or lack a profile photo.

*   **Filters disabled VPN servers:**
    *   Prevents VPN servers marked as disabled in the backend from appearing in the bot's server selection interface, providing a clearer user experience.
    *   Employs a reflection-based helper to check for the `IsDisabled` property, ensuring compatibility with different `SharedModels` versions.

The bot's internal version is bumped to 1.2.3.11, and the `DataGateMonitor.SharedModels` dependency is updated to 1.0.14 to support these new functionalities.