### PR TITLE
fix(bot): use /login_code only and backend localization for login codes

### DIFF
--- a/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
+++ b/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <!-- SharedModels: NuGet only (never ProjectReference). -->
-    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.18" />
+    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.19" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataGateVPNBot\DataGateVPNBot.csproj" />

--- a/DataGateVPNBot.Tests/Localization/LocalizationPlaceholderFormatterTests.cs
+++ b/DataGateVPNBot.Tests/Localization/LocalizationPlaceholderFormatterTests.cs
@@ -1,0 +1,35 @@
+using DataGateVPNBot.Localization;
+using Xunit;
+
+namespace DataGateVPNBot.Tests.Localization;
+
+public class LocalizationPlaceholderFormatterTests
+{
+    [Fact]
+    public void Apply_replaces_all_placeholders()
+    {
+        const string template = "Code: <code>{code}</code>, {minutes} min.";
+
+        var result = LocalizationPlaceholderFormatter.Apply(
+            template,
+            new Dictionary<string, string>
+            {
+                ["code"] = "ABCD1234",
+                ["minutes"] = "5",
+            });
+
+        Assert.Equal("Code: <code>ABCD1234</code>, 5 min.", result);
+    }
+
+    [Fact]
+    public void Apply_leaves_unknown_placeholders_unchanged()
+    {
+        const string template = "Hello {name}";
+
+        var result = LocalizationPlaceholderFormatter.Apply(
+            template,
+            new Dictionary<string, string> { ["code"] = "X" });
+
+        Assert.Equal("Hello {name}", result);
+    }
+}

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <!-- SharedModels: NuGet only (never ProjectReference). Bump after publishing a new package version. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.18" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.19" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.Localization.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.Localization.cs
@@ -1,4 +1,5 @@
-﻿using DataGateVPNBot.Services.BotServices.Interfaces;
+﻿using DataGateVPNBot.Localization;
+using DataGateVPNBot.Services.BotServices.Interfaces;
 using DataGateVPNBot.Services.DashboardServices.Interfaces;
 using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotLocalization.Requests;
 using DataGateMonitor.SharedModels.Enums;
@@ -86,5 +87,15 @@ public partial class TelegramUpdateHandler
         var localizationService = scope.ServiceProvider.GetRequiredService<ILocalizationService>();
         var request = new GetTextForTelegramUserRequest() { TelegramId = telegramId, Key = key };
         return (await localizationService.GetTextForTelegramUser(request, cancellationToken)).Text;
+    }
+
+    private async Task<string> GetLocalizationTextAsync(
+        string key,
+        long telegramId,
+        IReadOnlyDictionary<string, string> placeholders,
+        CancellationToken cancellationToken)
+    {
+        var template = await GetLocalizationTextAsync(key, telegramId, cancellationToken);
+        return LocalizationPlaceholderFormatter.Apply(template, placeholders);
     }
 }

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.LoginCode.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.LoginCode.cs
@@ -6,40 +6,31 @@ namespace DataGateVPNBot.Handlers;
 
 public partial class TelegramUpdateHandler
 {
-    private static readonly string[] LoginCodeTextTriggers =
-    [
-        "дай код",
-        "дайте код",
-        "give code",
-        "login code",
-    ];
-
-    private static bool IsLoginCodeTextRequest(string messageText)
-    {
-        var normalized = messageText.Trim().ToLowerInvariant();
-        return LoginCodeTextTriggers.Any(t => normalized == t || normalized.StartsWith(t + " ", StringComparison.Ordinal));
-    }
-
     private async Task<Message> SendDashboardLoginCodeAsync(Message msg, CancellationToken cancellationToken)
     {
         if (msg.From is null)
             return msg;
 
-        var result = await authService.RequestDashboardLoginCodeAsync(msg.From.Id, cancellationToken);
+        var telegramId = msg.From.Id;
+        var result = await authService.RequestDashboardLoginCodeAsync(telegramId, cancellationToken);
         if (result is null || string.IsNullOrWhiteSpace(result.Code))
         {
             return await _botClient.SendMessage(
                 msg.Chat,
-                "Could not issue a login code. Register in the bot with /register first, or contact support if you are blocked.",
+                await GetLocalizationTextAsync("DashboardLoginCodeError", telegramId, cancellationToken),
                 cancellationToken: cancellationToken);
         }
 
         var minutes = Math.Max(1, result.ExpiresInSeconds / 60);
-        var text =
-            $"Your dashboard login code:\n\n" +
-            $"<code>{result.Code}</code>\n\n" +
-            $"Valid for {minutes} min. Enter it on the DataGate Monitor sign-in page under «Continue with Telegram».\n" +
-            "Do not share this code.";
+        var text = await GetLocalizationTextAsync(
+            "DashboardLoginCode",
+            telegramId,
+            new Dictionary<string, string>
+            {
+                ["code"] = result.Code,
+                ["minutes"] = minutes.ToString(),
+            },
+            cancellationToken);
 
         return await _botClient.SendMessage(
             msg.Chat,

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
@@ -92,9 +92,6 @@ public partial class TelegramUpdateHandler(
     {
         var isPrivate = msg.Chat.Type == ChatType.Private;
 
-        if (isPrivate && IsLoginCodeTextRequest(messageText))
-            return await SendDashboardLoginCodeAsync(msg, cancellationToken);
-
         var commandParts = messageText.Split(' ', 2);
         var rawCommand = commandParts[0].ToLower();
         var command = rawCommand.Split('@')[0]; // remove @BotUsername

--- a/DataGateVPNBot/Localization/LocalizationPlaceholderFormatter.cs
+++ b/DataGateVPNBot/Localization/LocalizationPlaceholderFormatter.cs
@@ -1,0 +1,15 @@
+namespace DataGateVPNBot.Localization;
+
+public static class LocalizationPlaceholderFormatter
+{
+    public static string Apply(string template, IReadOnlyDictionary<string, string> placeholders)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+        ArgumentNullException.ThrowIfNull(placeholders);
+
+        foreach (var (name, value) in placeholders)
+            template = template.Replace($"{{{name}}}", value, StringComparison.Ordinal);
+
+        return template;
+    }
+}


### PR DESCRIPTION
Remove free-text phrase triggers; build user messages from localization API.
Bump SharedModels to 1.0.19.
