### PR TITLE
chore: align Telegram bot with backend ApiResponse and Newtonsoft JSON (v1.2.3.13)

### DIFF
--- a/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
+++ b/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <!-- SharedModels: NuGet only (never ProjectReference). -->
-    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.19" />
+    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.20" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataGateVPNBot\DataGateVPNBot.csproj" />

--- a/DataGateVPNBot.Tests/Services/HttpRequestServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/HttpRequestServiceTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Text;
-using System.Text.Json;
 using DataGateVPNBot.Services.Http;
 using DataGateVPNBot.Services.Interfaces;
 using Microsoft.Extensions.DependencyInjection;

--- a/DataGateVPNBot/Configurations/ServiceConfiguration.cs
+++ b/DataGateVPNBot/Configurations/ServiceConfiguration.cs
@@ -39,7 +39,7 @@ public static class ServiceConfiguration
         
         services.ConfigureTelegramBotMvc();
 
-        services.AddControllers();
+        services.AddControllers().AddNewtonsoftJson();
 
         services.AddEndpointsApiExplorer();
         services.AddSwaggerGen();

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -18,10 +18,11 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <!-- SharedModels: NuGet only (never ProjectReference). Bump after publishing a new package version. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.19" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.20" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -6,8 +6,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <ApplicationIcon>logo/logo.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.3.12</AssemblyVersion>
-        <FileVersion>1.2.3.12</FileVersion>
+        <AssemblyVersion>1.2.3.13</AssemblyVersion>
+        <FileVersion>1.2.3.13</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DataGateVPNBot/Middlewares/TmaAuthMiddleware.cs
+++ b/DataGateVPNBot/Middlewares/TmaAuthMiddleware.cs
@@ -1,6 +1,7 @@
 ﻿using System.Security.Cryptography;
 using System.Text;
-using System.Text.Json;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Microsoft.Extensions.Primitives;
 
 namespace DataGateVPNBot.Middlewares;
@@ -57,14 +58,14 @@ public sealed class TmaAuthMiddleware(RequestDelegate next, string botToken, Tim
     {
         ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
         ctx.Response.ContentType = "application/json";
-        await ctx.Response.WriteAsync(JsonSerializer.Serialize(new { message }));
+        await ctx.Response.WriteAsync(JsonConvert.SerializeObject(new { message }));
     }
 
     private static async Task Problem(HttpContext ctx, int code, string message)
     {
         ctx.Response.StatusCode = code;
         ctx.Response.ContentType = "application/json";
-        await ctx.Response.WriteAsync(JsonSerializer.Serialize(new { message }));
+        await ctx.Response.WriteAsync(JsonConvert.SerializeObject(new { message }));
     }
 
     private static bool Validate(string initDataQuery, string botToken, TimeSpan maxAge, out string? error)
@@ -145,14 +146,9 @@ public sealed class TmaAuthMiddleware(RequestDelegate next, string botToken, Tim
             var userJson = nvc["user"];
             if (!string.IsNullOrEmpty(userJson))
             {
-                using var doc = JsonDocument.Parse(userJson);
-                data.User = doc.RootElement.Clone();
-
-                if (doc.RootElement.TryGetProperty("id", out var idEl) &&
-                    idEl.ValueKind == JsonValueKind.Number)
-                {
-                    data.UserId = idEl.GetInt64();
-                }
+                data.User = JObject.Parse(userJson);
+                if (data.User["id"]?.Type == JTokenType.Integer)
+                    data.UserId = data.User["id"]!.Value<long>();
             }
 
             return data;

--- a/DataGateVPNBot/Middlewares/TmaInitData.cs
+++ b/DataGateVPNBot/Middlewares/TmaInitData.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+﻿using Newtonsoft.Json.Linq;
 
 namespace DataGateVPNBot.Middlewares;
 
@@ -13,6 +13,6 @@ public sealed class TmaInitData
     public long? CanSendAfter { get; set; }
     public string? Receiver { get; set; }
     public string? Hash { get; set; }
-    public JsonElement? User { get; set; }
+    public JToken? User { get; set; }
     public long? UserId { get; set; }
 }

--- a/DataGateVPNBot/Services/BotServices/IncomingMessageLogService.cs
+++ b/DataGateVPNBot/Services/BotServices/IncomingMessageLogService.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+﻿using Newtonsoft.Json;
 using DataGateVPNBot.Services.BotServices.Interfaces;
 using DataGateVPNBot.Services.DashboardServices.Interfaces;
 using DataGateVPNBot.Services.Interfaces;
@@ -171,7 +171,7 @@ public class IncomingMessageLogService(IIncomingMessageLogSenderService incoming
         var fileName = $"{request.Message!.TelegramId}_{DateTime.UtcNow:yyyyMMdd_HHmmssfff}.json";
         var fullPath = Path.Combine(dir, fileName);
 
-        var json = JsonSerializer.Serialize(request, new JsonSerializerOptions { WriteIndented = true });
+        var json = JsonConvert.SerializeObject(request, Formatting.Indented);
 
         await File.WriteAllTextAsync(fullPath, json, cancellationToken);
     }

--- a/DataGateVPNBot/Services/Http/HttpRequestService.cs
+++ b/DataGateVPNBot/Services/Http/HttpRequestService.cs
@@ -1,7 +1,8 @@
 using System.Net.Http.Headers;
 using System.Text;
-using System.Text.Json;
 using DataGateVPNBot.Services.Interfaces;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace DataGateVPNBot.Services.Http;
 
@@ -11,6 +12,11 @@ public class HttpRequestService(
     ILogger<HttpRequestService> logger)
     : IHttpRequestService
 {
+    private static readonly JsonSerializerSettings JsonSettings = new()
+    {
+        ContractResolver = new CamelCasePropertyNamesContractResolver(),
+    };
+
     private readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(30);
 
     private HttpClient CreateClient(string? token)
@@ -42,18 +48,15 @@ public class HttpRequestService(
 
         logger.LogInformation("Received JSON from {Url}: {Json}", url, json);
 
-        return JsonSerializer.Deserialize<T>(json, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
+        return JsonConvert.DeserializeObject<T>(json, JsonSettings);
     }
 
     public async Task<T?> PostAsync<T>(string url, object data, string? token = null,
         CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("Sending POST request to {Url} with data: {Data}", url, JsonSerializer.Serialize(data));
+        logger.LogInformation("Sending POST request to {Url} with data: {Data}", url, JsonConvert.SerializeObject(data, JsonSettings));
         var client = CreateClient(token);
-        var content = new StringContent(JsonSerializer.Serialize(data), Encoding.UTF8, "application/json");
+        var content = new StringContent(JsonConvert.SerializeObject(data, JsonSettings), Encoding.UTF8, "application/json");
         return await SendRequestAsync<T>(() => client.PostAsync(url, content, cancellationToken), url,
             cancellationToken);
     }
@@ -61,9 +64,9 @@ public class HttpRequestService(
     public async Task<T?> PutAsync<T>(string url, object data, string? token = null,
         CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("Sending PUT request to {Url} with data: {Data}", url, JsonSerializer.Serialize(data));
+        logger.LogInformation("Sending PUT request to {Url} with data: {Data}", url, JsonConvert.SerializeObject(data, JsonSettings));
         var client = CreateClient(token);
-        var content = new StringContent(JsonSerializer.Serialize(data), Encoding.UTF8, "application/json");
+        var content = new StringContent(JsonConvert.SerializeObject(data, JsonSettings), Encoding.UTF8, "application/json");
         return await SendRequestAsync<T>(() => client.PutAsync(url, content, cancellationToken), url,
             cancellationToken);
     }
@@ -139,17 +142,13 @@ public class HttpRequestService(
                     return (T)(object)response;
                 }
 
-                var result = JsonSerializer.Deserialize<T>(responseContent, new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true
-                });
+                var result = JsonConvert.DeserializeObject<T>(responseContent, JsonSettings);
 
                 response.Dispose();
                 return result;
             }
             catch (OperationCanceledException ex) when (cts.Token.IsCancellationRequested)
             {
-                // await errorService.NotifyAdminsAboutExceptionAsync(ex, null, cancellationToken);
                 logger.LogError("Request to {Url} timed out (Attempt {Attempt}) Error: {Error}", 
                     url, attempt, ex.Message);
                 errorDetails.AppendLine($"Attempt {attempt}: Timeout after {_defaultTimeout.TotalSeconds} seconds.");
@@ -158,14 +157,14 @@ public class HttpRequestService(
             catch (HttpRequestException ex)
             {
                 await errorService.NotifyAdminsAboutExceptionAsync(ex, null, cancellationToken);
-                logger.LogError("Network error while accessing {Url} (Attempt {Attempt}): {Message}", url, attempt,
+                logger.LogError(ex, "Network error while accessing {Url} (Attempt {Attempt}): {Message}", url, attempt,
                     ex.Message);
                 errorDetails.AppendLine($"Attempt {attempt}: HttpRequestException - {ex.Message}");
             }
             catch (Exception ex)
             {
                 await errorService.NotifyAdminsAboutExceptionAsync(ex, null, cancellationToken);
-                logger.LogError("Unexpected error while accessing {Url} (Attempt {Attempt}): {Message}", url, attempt,
+                logger.LogError(ex, "Unexpected error while accessing {Url} (Attempt {Attempt}): {Message}", url, attempt,
                     ex.Message);
                 errorDetails.AppendLine($"Attempt {attempt}: Exception - {ex.GetType().Name}: {ex.Message}");
             }

--- a/DataGateVPNBot/Services/TelegramApi/WebhookService.cs
+++ b/DataGateVPNBot/Services/TelegramApi/WebhookService.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+using Newtonsoft.Json.Linq;
 using DataGateVPNBot.Extensions;
 using DataGateVPNBot.Models.Configurations;
 using Microsoft.Extensions.Options;
@@ -31,15 +31,13 @@ public class WebhookService(
         }
 
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
+        var root = JObject.Parse(json);
 
-        if (root.TryGetProperty("ok", out var ok) && ok.GetBoolean())
+        if (root["ok"]?.Value<bool>() == true)
         {
-            var result = root.GetProperty("result");
-            var currentUrl = result.TryGetProperty("url", out var urlElement) ? urlElement.GetString() : null;
-            var hasCustomCertificate = result.TryGetProperty("has_custom_certificate", out var certElement) 
-                                       && certElement.GetBoolean();
+            var result = root["result"] as JObject;
+            var currentUrl = result?["url"]?.Value<string>();
+            var hasCustomCertificate = result?["has_custom_certificate"]?.Value<bool>() == true;
 
             var expectedUrl = BuildWebhookUrl();
 


### PR DESCRIPTION
## Summary

Telegram bot release aligned with backend **ApiResponse** envelope contract (**SharedModels 1.0.20**).

- **HTTP client:** `HttpRequestService` switched from `System.Text.Json` to **Newtonsoft.Json** with camelCase resolver — matches backend/dashboard JSON shape for `ApiResponse<T>` deserialization.
- **Dashboard calls:** auth, server list, incoming message log, and related services consume wrapped `{ success, data, message }` responses.
- **TMA middleware / webhook:** JSON parsing moved to Newtonsoft (`JObject`) for consistency.
- **Bot API:** `VpnServerController` returns `ApiResponse<VpnServersResponse>`.
- **Version:** **1.2.3.13**

## SharedModels

Uses **DataGateMonitor.SharedModels 1.0.20** (NuGet only). No 1.0.24 bump required for this service.

## Deploy notes

- Deploy **with** backend envelope branch (**≥1.0.3.41**); bot ↔ dashboard HTTP must use the same JSON contract.
- Rolling restart of bot service; no DB migrations in this PR.

## Test plan

- [ ] `dotnet restore && dotnet build && dotnet test`
- [ ] Bot login / token refresh against dashboard API
- [ ] `/start`, server list, OVPN download flows — no deserialize errors in logs
- [ ] TMA mini-app auth: valid/invalid `initData` → 401 with JSON body
- [ ] Webhook setup check: correct URL detection after Telegram `getWebhookInfo`
- [ ] Incoming message log sync to dashboard succeeds (`ApiResponse` POST)