### PR TITLE
docs: refresh README for DataGate Monitor branding and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# DataGateVPNBot
+<h1 align="left">
+  <img src="https://raw.githubusercontent.com/IMKolganov/DataGateMonitorFrontend/main/public/favicon.svg" width="32" height="32" alt="" />
+  DataGateVPNBot
+</h1>
 
 Telegram bot for [DataGate](https://datagateapp.com/) / DataGate Monitor: registration, VPN config delivery, and user-facing commands.
 
@@ -105,7 +108,7 @@ CI/CD: see [.github/workflows/deploy.yml](.github/workflows/deploy.yml).
 
 | Contact | Link |
 |---------|------|
-| <img src="https://cdn.simpleicons.org/linkedin/0A66C2" width="16" height="16" alt="" /> **LinkedIn** | [linkedin.com/in/imkolganov](https://www.linkedin.com/in/imkolganov/?locale=en) |
+| <img src="https://api.iconify.design/simple-icons/linkedin.svg?color=%230A66C2" width="16" height="16" alt="" /> **LinkedIn** | [linkedin.com/in/imkolganov](https://www.linkedin.com/in/imkolganov/?locale=en) |
 | <img src="https://cdn.simpleicons.org/telegram/26A5E4" width="16" height="16" alt="" /> **Telegram** | [@KolganovIvan](https://t.me/KolganovIvan) |
 | <img src="https://cdn.simpleicons.org/buymeacoffee/FFDD00" width="16" height="16" alt="" /> **Buy Me a Coffee** | [buymeacoffee.com/imkolganov](https://buymeacoffee.com/imkolganov) |
 | <img src="https://cdn.simpleicons.org/github/181717" width="16" height="16" alt="" /> **GitHub** | [IMKolganov](https://github.com/IMKolganov) |

--- a/README.md
+++ b/README.md
@@ -1,117 +1,110 @@
 # DataGateVPNBot
 
-**DataGateVPNBot** is a Telegram bot for managing OpenVPN. It provides users with functions such as registration, configuration file generation, retrieving client configurations, and other useful information for working with VPN.
+Telegram bot for [DataGate](https://datagateapp.com/) / DataGate Monitor: registration, VPN config delivery, and user-facing commands.
 
-## Key Features
-
-- **Registration**: Register users in the system.
-- **OpenVPN Management**: Create and retrieve client configuration files.
-- **Language Selection**: Support for multiple languages (English, Russian, Greek).
-- **Interactive Keyboards**: Support for inline and reply keyboards.
-- **Polls**: Create and handle polls.
-- **Multiple Commands**: A variety of commands for bot interaction.
-
----
-
-## Commands
-
-The bot supports the following commands:
-
-| Command                   | Description                                                             |
-|---------------------------|-------------------------------------------------------------------------|
-| `/about_bot`              | Information about the bot.                                              |
-| `/how_to_use`             | Instructions on how to use VPN.                                         |
-| `/register`               | User registration.                                                      |
-| `/get_my_files`           | Retrieve VPN client configurations.                                     |
-| `/make_new_file`          | Create a new configuration file.                                        |
-| `/install_client`         | Links to download OpenVPN clients for various platforms.                |
-| `/about_project`          | Information about the project.                                          |
-| `/contacts`               | Developer contact information.                                          |
-| `/change_language`        | Language selection.                                                     |
-| `/poll`                   | Create an anonymous poll.                                               |
-| `/inline_buttons`         | Example of using inline keyboards.                                      |
-| `/keyboard`               | Example of using reply keyboards.                                       |
-| `/remove`                 | Remove the keyboard.                                                    |
-
----
-## Generate Configuration Files
-
-To generate `appsettings.json` and `appsettings.Development.json` from the template:
-
-1. Run the following command in the project root:
-   ```bash
-   ./generate_appsettings.sh
-   
-2. Ensure that the .env file exists in the project root with the necessary environment variables.
-This script uses appsettings.json.template and populates it with values from .env to create the required configuration files.
-   ```env
-   DB_HOST=localhost
-   DB_PORT=5432
-   DB_NAME=mydatabase
-   DB_USER=myuser
-   DB_PASS=mypassword
-   DB_SCHEMA=mydbschema
-   DB_MIGRATION_TABLE=__EFMigrationsHistory
-   BOT_TOKEN=mybottoken
-   BOT_WEBHOOK_URL=https://example.com/bot
-   OPENVPN_SERVER_IP=0.0.0.0
-
-## Installation and Launch
-
-### Prerequisites
-- Raspberry Pi with .NET 6 Runtime installed.
-- OpenVPN server.
-- Telegram Bot API Token (obtain the token via [@BotFather](https://t.me/BotFather)).
-
-### Installation Instructions
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/IMKolganov/DataGateVPNBot.git
-   cd DataGateVPNBot
-   ```
-
-2. Install dependencies:
-   ```bash
-   dotnet restore
-   ```
-
-3. Build the application:
-   ```bash
-   dotnet build
-   ```
-
-4. Run the bot:
-   ```bash
-   dotnet run
-   ```
-
-### Deployment on Raspberry Pi
-Automatic deployment is handled via **GitHub Actions**. See the [workflow file](.github/workflows/deploy.yml) for configuration details.
-
-### Deployment behind nginx
-Set `USE_CERTIFICATE=false`, `ForwardedHeaders__Enabled=true`, and `ForwardedHeaders__AllowAll=true`; app listens HTTP on `TELEGRAMBOT_LISTEN_PORT` (default 5050).
-
----
-
-## Main Components
-
-- **UpdateHandler**: Main handler for Telegram updates. Implements the core bot functionality.
-- **IOpenVpnClientService**: Interface for handling OpenVPN client configurations.
-- **ILocalizationService**: Interface for text localization.
-- **ITelegramRegistrationService**: Interface for user registration management.
-
----
+Part of the [DataGateMonitor](https://github.com/IMKolganov/DataGateMonitor) monorepo (`telegrambot/` submodule). Standalone repo: [DataGateVPNBot](https://github.com/IMKolganov/DataGateVPNBot).
 
 ## Links
 
-- [OpenVPN Client for Windows](https://openvpn.net/client-connect-vpn-for-windows/)
-- [OpenVPN Client for Android](https://play.google.com/store/apps/details?id=net.openvpn.openvpn)
-- [OpenVPN Client for iPhone](https://apps.apple.com/app/openvpn-connect/id590379981)
-- [Telegram API](https://core.telegram.org/bots/api)
+| | |
+|---|---|
+| **App download** | [datagateapp.com/download](https://datagateapp.com/download) |
+| **Dashboard** | [dash.datagateapp.com](https://dash.datagateapp.com/) |
+| **Telegram channel** | [@datagateapp](https://t.me/datagateapp) |
 
----
+## Key features
 
-## Contacts
+- User registration
+- OpenVPN / client configuration delivery
+- Multi-language support (English, Russian, Greek)
+- Inline and reply keyboards, polls
 
-Developer: [Kolganov Ivan](https://github.com/IMKolganov)  
-Contact via [Telegram](https://t.me/KolganovIvan)
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/about_bot` | Information about the bot |
+| `/how_to_use` | How to use VPN |
+| `/register` | Register in the system |
+| `/get_my_files` | Retrieve VPN client configurations |
+| `/make_new_file` | Create a new configuration file |
+| `/install_client` | Download links for OpenVPN clients |
+| `/about_project` | About the project |
+| `/contacts` | Developer contacts |
+| `/change_language` | Language selection |
+| `/poll` | Anonymous poll |
+| `/inline_buttons` | Inline keyboard example |
+| `/keyboard` | Reply keyboard example |
+| `/remove` | Remove keyboard |
+
+## Configuration
+
+Generate `appsettings.json` from template:
+
+```bash
+./generate_appsettings.sh
+```
+
+Requires a `.env` in the project root (see `appsettings.json.template`).
+
+## Installation and launch
+
+### Prerequisites
+
+- .NET SDK (see project `TargetFramework`)
+- PostgreSQL (when using DB features)
+- Telegram Bot token from [@BotFather](https://t.me/BotFather)
+- OpenVPN / backend integration as configured in compose
+
+### Local run
+
+```bash
+git clone https://github.com/IMKolganov/DataGateVPNBot.git
+cd DataGateVPNBot
+dotnet restore
+dotnet build
+dotnet run
+```
+
+### Docker (monorepo)
+
+From the monorepo root:
+
+```bash
+docker compose -f docker-compose-local.yml --env-file .env.dev.x64 up -d --build telegrambot
+```
+
+Image: `imkolganov/datagate-monitor-telegrambot`.
+
+Env: `TELEGRAMBOT_BOT_TOKEN`, `DASHBOARDAPI_*`, `ELASTIC_*`, etc. (see monorepo compose).
+
+### Deployment behind nginx
+
+Set `USE_CERTIFICATE=false`, `ForwardedHeaders__Enabled=true`, and `ForwardedHeaders__AllowAll=true`. The app listens on HTTP at `TELEGRAMBOT_LISTEN_PORT` (default `5050`).
+
+CI/CD: see [.github/workflows/deploy.yml](.github/workflows/deploy.yml).
+
+## Main components
+
+- **UpdateHandler** — Telegram update pipeline
+- **IOpenVpnClientService** — OpenVPN client configs
+- **ILocalizationService** — localization
+- **ITelegramRegistrationService** — registration
+
+## External links
+
+- [OpenVPN Connect (Windows)](https://openvpn.net/client-connect-vpn-for-windows/)
+- [OpenVPN Connect (Android)](https://play.google.com/store/apps/details?id=net.openvpn.openvpn)
+- [OpenVPN Connect (iOS)](https://apps.apple.com/app/openvpn-connect/id590379981)
+- [Telegram Bot API](https://core.telegram.org/bots/api)
+
+## Author
+
+**Ivan Kolganov**
+
+- [LinkedIn](https://www.linkedin.com/in/imkolganov/?locale=en)
+- [Telegram](https://t.me/KolganovIvan)
+- [Buy Me a Coffee](https://buymeacoffee.com/imkolganov)
+- GitHub: [IMKolganov](https://github.com/IMKolganov)
+
+Product channel: [@datagateapp](https://t.me/datagateapp)

--- a/README.md
+++ b/README.md
@@ -111,5 +111,5 @@ CI/CD: see [.github/workflows/deploy.yml](.github/workflows/deploy.yml).
 | <img src="https://api.iconify.design/simple-icons/linkedin.svg?color=%230A66C2" width="16" height="16" alt="" /> **LinkedIn** | [linkedin.com/in/imkolganov](https://www.linkedin.com/in/imkolganov/?locale=en) |
 | <img src="https://cdn.simpleicons.org/telegram/26A5E4" width="16" height="16" alt="" /> **Telegram** | [@KolganovIvan](https://t.me/KolganovIvan) |
 | <img src="https://cdn.simpleicons.org/buymeacoffee/FFDD00" width="16" height="16" alt="" /> **Buy Me a Coffee** | [buymeacoffee.com/imkolganov](https://buymeacoffee.com/imkolganov) |
-| <img src="https://cdn.simpleicons.org/github/181717" width="16" height="16" alt="" /> **GitHub** | [IMKolganov](https://github.com/IMKolganov) |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/github/ffffff"><img src="https://cdn.simpleicons.org/github/181717" width="16" height="16" alt=""></picture> **GitHub** | [IMKolganov](https://github.com/IMKolganov) |
 | <img src="https://cdn.simpleicons.org/telegram/26A5E4" width="16" height="16" alt="" /> **Product channel** | [@datagateapp](https://t.me/datagateapp) |

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ Part of the [DataGateMonitor](https://github.com/IMKolganov/DataGateMonitor) mon
 
 ## Links
 
-| | |
-|---|---|
-| **App download** | [datagateapp.com/download](https://datagateapp.com/download) |
-| **Dashboard** | [dash.datagateapp.com](https://dash.datagateapp.com/) |
-| **Telegram channel** | [@datagateapp](https://t.me/datagateapp) |
+| Resource | Link |
+|----------|------|
+| <img src="https://raw.githubusercontent.com/IMKolganov/DataGateMonitorFrontend/main/public/favicon.svg" width="16" height="16" alt="" /> **Product** | [datagateapp.com](https://datagateapp.com/) |
+| <img src="https://cdn.simpleicons.org/googleplay/414141" width="16" height="16" alt="" /> **Download** | [datagateapp.com/download](https://datagateapp.com/download) |
+| <img src="https://cdn.simpleicons.org/grafana/F46800" width="16" height="16" alt="" /> **Dashboard** | [dash.datagateapp.com](https://dash.datagateapp.com/) |
+| <img src="https://cdn.simpleicons.org/telegram/26A5E4" width="16" height="16" alt="" /> **Telegram channel** | [@datagateapp](https://t.me/datagateapp) |
 
 ## Key features
 
@@ -102,9 +103,10 @@ CI/CD: see [.github/workflows/deploy.yml](.github/workflows/deploy.yml).
 
 **Ivan Kolganov**
 
-- [LinkedIn](https://www.linkedin.com/in/imkolganov/?locale=en)
-- [Telegram](https://t.me/KolganovIvan)
-- [Buy Me a Coffee](https://buymeacoffee.com/imkolganov)
-- GitHub: [IMKolganov](https://github.com/IMKolganov)
-
-Product channel: [@datagateapp](https://t.me/datagateapp)
+| Contact | Link |
+|---------|------|
+| <img src="https://cdn.simpleicons.org/linkedin/0A66C2" width="16" height="16" alt="" /> **LinkedIn** | [linkedin.com/in/imkolganov](https://www.linkedin.com/in/imkolganov/?locale=en) |
+| <img src="https://cdn.simpleicons.org/telegram/26A5E4" width="16" height="16" alt="" /> **Telegram** | [@KolganovIvan](https://t.me/KolganovIvan) |
+| <img src="https://cdn.simpleicons.org/buymeacoffee/FFDD00" width="16" height="16" alt="" /> **Buy Me a Coffee** | [buymeacoffee.com/imkolganov](https://buymeacoffee.com/imkolganov) |
+| <img src="https://cdn.simpleicons.org/github/181717" width="16" height="16" alt="" /> **GitHub** | [IMKolganov](https://github.com/IMKolganov) |
+| <img src="https://cdn.simpleicons.org/telegram/26A5E4" width="16" height="16" alt="" /> **Product channel** | [@datagateapp](https://t.me/datagateapp) |


### PR DESCRIPTION
## Summary
Documentation-only PR: refresh README(s) for **DataGate Monitor** branding and public links.
- Rename legacy **OpenVPN Gate Monitor** references to **DataGate Monitor**
- Add product links: [datagateapp.com](https://datagateapp.com/), [download](https://datagateapp.com/download), [dashboard](https://dash.datagateapp.com/), [@datagateapp](https://t.me/datagateapp)
- Add author / support links: [LinkedIn](https://www.linkedin.com/in/imkolganov/?locale=en), [Telegram](https://t.me/KolganovIvan), [Buy Me a Coffee](https://buymeacoffee.com/imkolganov)
- Expand dev quick-start (`README-DEV.md` in monorepo)
- Add DataGate logo to README title and icons in Links / Author tables
- Fix README table headers (`Resource | Link`, `Contact | Link`)
- Fix broken LinkedIn icon URL (simpleicons CDN → iconify)
- Fix GitHub icon visibility on dark theme (`<picture>` light/dark)
- Monorepo: add `docs/assets/datagate.svg` (favicon cannot live under `frontend/` submodule path)
No runtime, API, or deployment changes.
## Test plan
- [ ] Open README on GitHub (light + dark theme)
- [ ] Verify title logo, Links table icons, Author table icons render correctly
- [ ] Confirm all external links open (product, download, dashboard, Telegram, LinkedIn, BMC, GitHub)
- [ ] Monorepo only: confirm `docs/assets/datagate.svg` opens on GitHub (not `frontend/public/…`)
- [ ] No code/build changes required