### PR TITLE
Bump SharedModels to 1.0.25

### DIFF
--- a/DataGateVPNBot.Models/DataGateVPNBot.Models.csproj
+++ b/DataGateVPNBot.Models/DataGateVPNBot.Models.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Telegram.Bot" Version="22.10.0.1" />
+      <PackageReference Include="Telegram.Bot" Version="22.10.1" />
     </ItemGroup>
 
 </Project>

--- a/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
+++ b/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <!-- SharedModels: NuGet only (never ProjectReference). -->
-    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.20" />
+    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.25" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataGateVPNBot\DataGateVPNBot.csproj" />

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -13,24 +13,24 @@
     <ItemGroup>
         <PackageReference Include="ACMESharpCore" Version="2.2.0.148" />
         <PackageReference Include="Certes" Version="3.0.4" />
-        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.4.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
         <!-- SharedModels: NuGet only (never ProjectReference). Bump after publishing a new package version. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.20" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.25" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.7" />
-        <PackageReference Include="Telegram.Bot" Version="22.10.0.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.2" />
+        <PackageReference Include="Telegram.Bot" Version="22.10.1" />
         <PackageReference Include="Telegram.Bot.AspNetCore" Version="22.5.0" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Bump `DataGateMonitor.SharedModels` from 1.0.20 to **1.0.25** in bot and tests projects.
- Align ASP.NET, EF Core, Elasticsearch, Swashbuckle, and Telegram.Bot package versions.

Telegrambot controllers already consume SharedModels for VPN/OVPN API calls; this keeps the package in sync with backend, openvpn, and xray.

## Test plan
- [x] `dotnet build DataGateVPNBot -c Release`
- [ ] `dotnet test DataGateVPNBot.Tests -c Release`