### PR TITLE
Bump NuGet dependencies

### DIFF
--- a/DataGateVPNBot.DataBase/DataGateVPNBot.DataBase.csproj
+++ b/DataGateVPNBot.DataBase/DataGateVPNBot.DataBase.csproj
@@ -12,11 +12,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     </ItemGroup>
 
 </Project>

--- a/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
+++ b/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <!-- SharedModels: NuGet only (never ProjectReference). -->
-    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.27" />
+    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.34" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataGateVPNBot\DataGateVPNBot.csproj" />

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -22,14 +22,14 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
         <!-- SharedModels: NuGet only (never ProjectReference). Bump after publishing a new package version. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.27" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.34" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />
         <PackageReference Include="Telegram.Bot" Version="22.10.1" />
         <PackageReference Include="Telegram.Bot.AspNetCore" Version="22.5.0" />
     </ItemGroup>


### PR DESCRIPTION
## Summary
- Bump SharedModels to 1.0.34, Swashbuckle to 10.2.3, EF Core/Npgsql, and test SDK.

## Test plan
- [ ] `dotnet build`
- [ ] `dotnet test`