### PR TITLE
Account link by code and free-tier VPN access gate

### DIFF
--- a/DataGateVPNBot.Models/Configurations/BotConfiguration.cs
+++ b/DataGateVPNBot.Models/Configurations/BotConfiguration.cs
@@ -11,4 +11,10 @@ public class BotConfiguration
     public string? CertificatePfxPath { get; set; } = "app/resources/certs/datagatetgbot.pfx";
     public string? CertificatePemPath { get; set; } = "app/resources/certs/datagatetgbot.pem";
     public TimeSpan? InitDataLifetime { get; set; }
+
+    /// <summary>Required public channel username without @ (default: DataGateVPNBot).</summary>
+    public string RequiredChannelUsername { get; set; } = "DataGateVPNBot";
+
+    public string RequiredChannelChatId =>
+        $"@{RequiredChannelUsername.Trim().TrimStart('@')}";
 }

--- a/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
+++ b/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <!-- SharedModels: NuGet only (never ProjectReference). -->
-    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.34" />
+    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.35" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataGateVPNBot\DataGateVPNBot.csproj" />

--- a/DataGateVPNBot.Tests/Helpers/AccountLinkCodeParserTests.cs
+++ b/DataGateVPNBot.Tests/Helpers/AccountLinkCodeParserTests.cs
@@ -19,4 +19,25 @@ public class AccountLinkCodeParserTests
         Assert.Equal(expected, ok);
         Assert.Equal(expectedCode, code);
     }
+
+    [Theory]
+    [InlineData("ABCD2345 extra", true, "ABCD2345")]
+    [InlineData("  abcd2345  ", true, "ABCD2345")]
+    [InlineData("abc", false, "")]
+    public void TryNormalizeToken_ParsesFirstToken(string input, bool expected, string expectedCode)
+    {
+        var ok = AccountLinkCodeParser.TryNormalizeToken(input, out var code);
+
+        Assert.Equal(expected, ok);
+        Assert.Equal(expectedCode, code);
+    }
+
+    [Theory]
+    [InlineData("ABCD2345", "[account-link-code-redacted]")]
+    [InlineData("/link_account ABCD2345", "/link_account [redacted]")]
+    [InlineData("hello", "hello")]
+    public void RedactSensitiveMessageText_RedactsLinkCodes(string input, string expected)
+    {
+        Assert.Equal(expected, AccountLinkCodeParser.RedactSensitiveMessageText(input));
+    }
 }

--- a/DataGateVPNBot.Tests/Helpers/AccountLinkCodeParserTests.cs
+++ b/DataGateVPNBot.Tests/Helpers/AccountLinkCodeParserTests.cs
@@ -1,0 +1,22 @@
+using DataGateVPNBot.Helpers;
+using Xunit;
+
+namespace DataGateVPNBot.Tests.Helpers;
+
+public class AccountLinkCodeParserTests
+{
+    [Theory]
+    [InlineData("ABCD2345", true, "ABCD2345")]
+    [InlineData("abcd2345", true, "ABCD2345")]
+    [InlineData("/link_account ABCD2345", false, "")]
+    [InlineData("SHORT", false, "")]
+    [InlineData("ABCD234!", false, "")]
+    [InlineData("12345678", false, "")]
+    public void TryExtract_ParsesEightCharacterCodes(string input, bool expected, string expectedCode)
+    {
+        var ok = AccountLinkCodeParser.TryExtract(input, out var code);
+
+        Assert.Equal(expected, ok);
+        Assert.Equal(expectedCode, code);
+    }
+}

--- a/DataGateVPNBot.Tests/Services/AuthServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/AuthServiceTests.cs
@@ -3,6 +3,7 @@ using DataGateVPNBot.Services.Http;
 using Microsoft.Extensions.Logging;
 using Moq;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+using DataGateMonitor.SharedModels.DataGateMonitor.User.Responses;
 using DataGateMonitor.SharedModels.Responses;
 using Xunit;
 
@@ -76,5 +77,48 @@ public class AuthServiceTests
         Assert.Equal("cached-token", first);
         Assert.Equal("cached-token", second);
         Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task CompleteAccountLinkAsync_ReturnsNull_WhenTokenUnavailable()
+    {
+        var httpRequest = new Mock<IHttpRequestService>();
+        httpRequest.Setup(h => h.PostAsync<ApiResponse<TokenResponse>>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<TokenResponse> { Success = false });
+
+        var sut = new AuthService(httpRequest.Object, "clientId", "secret", Mock.Of<ILogger<AuthService>>());
+
+        var result = await sut.CompleteAccountLinkAsync("ABCD2345", 12345, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task CompleteAccountLinkAsync_ReturnsResponse_WhenApiSucceeds()
+    {
+        var httpRequest = new Mock<IHttpRequestService>();
+        httpRequest.Setup(h => h.PostAsync<ApiResponse<TokenResponse>>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<TokenResponse>
+            {
+                Success = true,
+                Data = new TokenResponse { Token = "jwt", Expiration = DateTimeOffset.UtcNow.AddHours(1) },
+            });
+        httpRequest.Setup(h => h.PostAsync<ApiResponse<CompleteTelegramAccountLinkResponse>>(
+                "api/users/merge-telegram-google/by-link-code",
+                It.IsAny<object>(),
+                "jwt",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<CompleteTelegramAccountLinkResponse>
+            {
+                Success = true,
+                Data = new CompleteTelegramAccountLinkResponse { Success = true, Message = "Linked" },
+            });
+
+        var sut = new AuthService(httpRequest.Object, "clientId", "secret", Mock.Of<ILogger<AuthService>>());
+
+        var result = await sut.CompleteAccountLinkAsync("ABCD2345", 12345, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.True(result!.Success);
     }
 }

--- a/DataGateVPNBot.Tests/Services/FreeTierAccessComplianceBotServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/FreeTierAccessComplianceBotServiceTests.cs
@@ -29,7 +29,7 @@ public class FreeTierAccessComplianceBotServiceTests
     }
 
     [Fact]
-    public void BuildChannelSubscriptionRequiredMessage_IncludesConfiguredChannel()
+    public void BuildAccessDeniedMessage_IncludesChannelAndLinkAccountHint()
     {
         var service = new FreeTierAccessComplianceBotService(
             Mock.Of<Telegram.Bot.ITelegramBotClient>(),
@@ -42,10 +42,11 @@ public class FreeTierAccessComplianceBotServiceTests
             null!,
             Mock.Of<Microsoft.Extensions.Logging.ILogger<FreeTierAccessComplianceBotService>>());
 
-        var message = service.BuildChannelSubscriptionRequiredMessage();
+        var message = service.BuildAccessDeniedMessage();
 
         Assert.Contains("@DataGateVPNBot", message);
-        Assert.Contains("не обнаружена подписка", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("/link_account", message);
+        Assert.Contains("linked account", message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/DataGateVPNBot.Tests/Services/FreeTierAccessComplianceBotServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/FreeTierAccessComplianceBotServiceTests.cs
@@ -1,0 +1,59 @@
+using DataGateVPNBot.Services.BotServices;
+using Moq;
+using Telegram.Bot.Types;
+using Xunit;
+
+namespace DataGateVPNBot.Tests.Services;
+
+public class FreeTierAccessComplianceBotServiceTests
+{
+    [Fact]
+    public void IsActiveMember_RecognizesMemberStatus()
+    {
+        Assert.True(FreeTierAccessComplianceBotService.IsActiveMember(new ChatMemberMember()));
+    }
+
+    [Fact]
+    public void IsActiveMember_RejectsLeftStatus()
+    {
+        Assert.False(FreeTierAccessComplianceBotService.IsActiveMember(new ChatMemberLeft()));
+    }
+
+    [Theory]
+    [InlineData(12345, true, "api/users/audit-free-tier-access/by-telegram/12345?channelSubscribed=true")]
+    [InlineData(12345, false, "api/users/audit-free-tier-access/by-telegram/12345?channelSubscribed=false")]
+    [InlineData(12345, null, "api/users/audit-free-tier-access/by-telegram/12345")]
+    public void BuildAuditEndpoint_FormatsQueryFlag(long telegramId, bool? channelSubscribed, string expected)
+    {
+        Assert.Equal(expected, FreeTierAccessComplianceBotService.BuildAuditEndpoint(telegramId, channelSubscribed));
+    }
+
+    [Fact]
+    public void BuildChannelSubscriptionRequiredMessage_IncludesConfiguredChannel()
+    {
+        var service = new FreeTierAccessComplianceBotService(
+            Mock.Of<Telegram.Bot.ITelegramBotClient>(),
+            Microsoft.Extensions.Options.Options.Create(
+                new DataGateVPNBot.Models.Configurations.BotConfiguration
+                {
+                    RequiredChannelUsername = "DataGateVPNBot",
+                }),
+            null!,
+            null!,
+            Mock.Of<Microsoft.Extensions.Logging.ILogger<FreeTierAccessComplianceBotService>>());
+
+        var message = service.BuildChannelSubscriptionRequiredMessage();
+
+        Assert.Contains("@DataGateVPNBot", message);
+        Assert.Contains("не обнаружена подписка", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void VpnAccessGateResult_Denied_CarriesUserMessage()
+    {
+        var result = VpnAccessGateResult.Denied("blocked");
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal("blocked", result.UserMessage);
+    }
+}

--- a/DataGateVPNBot.Tests/Services/IncomingMessageLogServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/IncomingMessageLogServiceTests.cs
@@ -84,4 +84,27 @@ public class IncomingMessageLogServiceTests
                 Directory.Delete(tempDir, recursive: true);
         }
     }
+
+    [Fact]
+    public async Task Log_Message_RedactsAccountLinkCode()
+    {
+        AddMessageRequest? capturedRequest = null;
+        var sender = new Mock<IIncomingMessageLogSenderService>();
+        sender.Setup(s => s.TelegramBotIncomingMessageLogAddMessageAsync(It.IsAny<AddMessageRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<AddMessageRequest, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new AddMessageResponse());
+
+        var sut = new IncomingMessageLogService(sender.Object, Mock.Of<IErrorService>(), Mock.Of<ILogger<IncomingMessageLogService>>());
+        var msg = new Message
+        {
+            From = new User { Id = 42, IsBot = false },
+            Date = DateTime.UtcNow,
+            Chat = new Chat { Id = 1, Type = ChatType.Private },
+            Text = "ABCD2345",
+        };
+
+        await sut.Log(Mock.Of<ITelegramBotClient>(), msg, CancellationToken.None);
+
+        Assert.Equal("[account-link-code-redacted]", capturedRequest!.Message!.MessageText);
+    }
 }

--- a/DataGateVPNBot.Tests/Services/OvpnFileServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/OvpnFileServiceTests.cs
@@ -7,6 +7,7 @@ using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Responses;
 using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Responses.Dto;
 using DataGateMonitor.SharedModels.Responses;
 using DataGateVPNBot.Services.BotServices;
+using DataGateVPNBot.Services.BotServices.Interfaces;
 using DataGateVPNBot.Services.Interfaces;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
 using BotServices = DataGateVPNBot.Services.BotServices;

--- a/DataGateVPNBot.Tests/Services/TelegramBotUserServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/TelegramBotUserServiceTests.cs
@@ -38,4 +38,27 @@ public class TelegramBotUserServiceTests
         await Assert.ThrowsAsync<System.Security.Authentication.AuthenticationException>(() =>
             sut.GetAdminsAsync(CancellationToken.None));
     }
+
+    [Fact]
+    public async Task UserExistsAsync_ReturnsFalse_WhenApiReportsNotRegistered_WithoutWarning()
+    {
+        var httpRequest = new Mock<IHttpRequestService>();
+        httpRequest.Setup(h => h.PostAsync<ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>>(
+                It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>
+            {
+                Success = true,
+                Data = new DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse { Token = "t" },
+            });
+        httpRequest.Setup(h => h.GetAsync<ApiResponse<bool>>(
+                "api/tgbot-users/check-exists/372608421", "t", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<bool> { Success = true, Data = false, Message = "Success" });
+
+        var authService = new AuthService(httpRequest.Object, "c", "s", Mock.Of<ILogger<AuthService>>());
+        var sut = new TelegramBotUserService(Mock.Of<ILogger<TelegramBotUserService>>(), httpRequest.Object, authService, Mock.Of<IErrorService>());
+
+        var exists = await sut.UserExistsAsync(372608421, CancellationToken.None);
+
+        Assert.False(exists);
+    }
 }

--- a/DataGateVPNBot/Configurations/ServiceConfiguration.cs
+++ b/DataGateVPNBot/Configurations/ServiceConfiguration.cs
@@ -32,6 +32,7 @@ public static class ServiceConfiguration
         services.AddSingleton<ITelegramSettingsService, TelegramSettingsService>();
         services.AddScoped<IOpenVpnServersService, OpenVpnServersService>();
         services.AddScoped<IOvpnFileService, OvpnFileService>();
+        services.AddScoped<IFreeTierAccessComplianceBotService, FreeTierAccessComplianceBotService>();
         services.AddScoped<IXrayClientLinkBotService, XrayClientLinkBotService>();
         services.AddScoped<IVpnProfileTokenDownloadService, VpnProfileTokenDownloadService>();
         services.AddSingleton<ServerService>();

--- a/DataGateVPNBot/Configurations/TelegramConfigurationHelper.cs
+++ b/DataGateVPNBot/Configurations/TelegramConfigurationHelper.cs
@@ -18,6 +18,7 @@ public static class TelegramConfigurationHelper
         var envCertPemPath = Environment.GetEnvironmentVariable("CERTIFICATE_PEM_PATH");
         var envUseCert = Environment.GetEnvironmentVariable("USE_CERTIFICATE");
         var envAutoGen = Environment.GetEnvironmentVariable("AUTO_GENERATE_CERTIFICATE");
+        var envRequiredChannel = Environment.GetEnvironmentVariable("TELEGRAM_REQUIRED_CHANNEL_USERNAME");
 
         if (!string.IsNullOrWhiteSpace(envBotToken)) botConfig.BotToken = envBotToken;
         if (!string.IsNullOrWhiteSpace(envHost)) botConfig.HostAddress = envHost;
@@ -29,6 +30,8 @@ public static class TelegramConfigurationHelper
 
         if (bool.TryParse(envUseCert, out var useCert)) botConfig.UseCertificate = useCert;
         if (bool.TryParse(envAutoGen, out var autoGen)) botConfig.AutoGenerateCertificate = autoGen;
+        if (!string.IsNullOrWhiteSpace(envRequiredChannel))
+            botConfig.RequiredChannelUsername = envRequiredChannel.Trim().TrimStart('@');
 
         if (!string.IsNullOrWhiteSpace(botConfig.HostAddress))
             botConfig.HostAddress = HostAddressNormalizer.Normalize(botConfig.HostAddress);

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
         <!-- SharedModels: NuGet only (never ProjectReference). Bump after publishing a new package version. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.34" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.35" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -6,8 +6,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <ApplicationIcon>logo/logo.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.3.13</AssemblyVersion>
-        <FileVersion>1.2.3.13</FileVersion>
+        <AssemblyVersion>1.2.3.14</AssemblyVersion>
+        <FileVersion>1.2.3.14</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DataGateVPNBot/Handlers/BotCommands.cs
+++ b/DataGateVPNBot/Handlers/BotCommands.cs
@@ -8,6 +8,8 @@ public static class BotCommands
     public const string CommandRegister = "/register";
     /// <summary>One-time dashboard login code (5 minutes).</summary>
     public const string CommandLoginCode = "/login_code";
+    /// <summary>Link dashboard (Google/password) account using a code from the client app.</summary>
+    public const string CommandLinkAccount = "/link_account";
     public const string CommandGetMyFiles = "/get_my_files";
     public const string CommandGetMyFilesWithToken = "/get_my_files_with_token";
     public const string CommandGetMyFilesWithoutToken = "/get_my_files_without_token";

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.AccountLink.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.AccountLink.cs
@@ -1,0 +1,84 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+
+namespace DataGateVPNBot.Handlers;
+
+public partial class TelegramUpdateHandler
+{
+    private async Task<Message> CompleteAccountLinkFromBotAsync(
+        Message msg,
+        string code,
+        CancellationToken cancellationToken)
+    {
+        if (msg.From is null)
+            return msg;
+
+        var telegramId = msg.From.Id;
+        var result = await authService.CompleteAccountLinkAsync(code, telegramId, cancellationToken);
+
+        var text = result switch
+        {
+            { Success: true, Merge: not null } mergeOk =>
+                "✅ Аккаунты успешно связаны.\n" +
+                "✅ Accounts linked successfully.\n\n" +
+                $"User #{mergeOk.Merge!.SurvivorUserId}" +
+                (mergeOk.Merge.Warnings.Count > 0
+                    ? "\n\n⚠️ " + string.Join("\n⚠️ ", mergeOk.Merge.Warnings)
+                    : string.Empty),
+            { Success: true } ok =>
+                "✅ " + (string.IsNullOrWhiteSpace(ok.Message)
+                    ? "Accounts linked successfully."
+                    : ok.Message),
+            _ =>
+                "❌ " + (string.IsNullOrWhiteSpace(result?.Message)
+                    ? "Could not link accounts. Check the code and try again."
+                    : result!.Message),
+        };
+
+        return await _botClient.SendMessage(
+            msg.Chat,
+            text,
+            cancellationToken: cancellationToken);
+    }
+
+    private async Task<Message> LinkAccountCommandAsync(
+        Message msg,
+        string? codeArgument,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(codeArgument))
+        {
+            return await _botClient.SendMessage(
+                msg.Chat,
+                "Введите код из приложения:\n/link_account КОД\n\n" +
+                "Or send the 8-character code alone in this chat.\n\n" +
+                "Enter the code from the app:\n/link_account CODE",
+                cancellationToken: cancellationToken);
+        }
+
+        return await CompleteAccountLinkFromBotAsync(msg, codeArgument.Trim(), cancellationToken);
+    }
+
+    private static bool TryExtractAccountLinkCode(string messageText, out string code)
+    {
+        code = string.Empty;
+        var trimmed = messageText.Trim();
+        if (trimmed.StartsWith('/'))
+            return false;
+
+        if (trimmed.Length != 8)
+            return false;
+
+        foreach (var ch in trimmed)
+        {
+            if (!IsAccountLinkCodeChar(ch))
+                return false;
+        }
+
+        code = trimmed.ToUpperInvariant();
+        return true;
+    }
+
+    private static bool IsAccountLinkCodeChar(char ch)
+        => ch is >= 'A' and <= 'Z' or >= '2' and <= '9';
+}

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.AccountLink.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.AccountLink.cs
@@ -31,6 +31,8 @@ public partial class TelegramUpdateHandler
                 "✅ " + (string.IsNullOrWhiteSpace(ok.Message)
                     ? "Accounts linked successfully."
                     : ok.Message),
+            { Message: var message } when message.Contains("not registered", StringComparison.OrdinalIgnoreCase) =>
+                "❌ " + message + "\n\nИспользуйте /register в боте.\nUse /register in the bot first.",
             _ =>
                 "❌ " + (string.IsNullOrWhiteSpace(result?.Message)
                     ? "Could not link accounts. Check the code and try again."
@@ -58,12 +60,18 @@ public partial class TelegramUpdateHandler
                 cancellationToken: cancellationToken);
         }
 
-        return await CompleteAccountLinkFromBotAsync(msg, codeArgument.Trim(), cancellationToken);
+        if (!AccountLinkCodeParser.TryNormalizeToken(codeArgument, out var code))
+        {
+            return await _botClient.SendMessage(
+                msg.Chat,
+                "❌ Неверный формат кода. Нужны 8 символов (A-Z, 2-9).\n" +
+                "❌ Invalid code format. Expected 8 characters (A-Z, 2-9).",
+                cancellationToken: cancellationToken);
+        }
+
+        return await CompleteAccountLinkFromBotAsync(msg, code, cancellationToken);
     }
 
     private static bool TryExtractAccountLinkCode(string messageText, out string code)
         => AccountLinkCodeParser.TryExtract(messageText, out code);
-
-    private static bool IsAccountLinkCodeChar(char ch)
-        => AccountLinkCodeParser.IsCodeChar(ch);
 }

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.AccountLink.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.AccountLink.cs
@@ -1,12 +1,13 @@
 using DataGateVPNBot.Helpers;
 using Telegram.Bot;
 using Telegram.Bot.Types;
-using Telegram.Bot.Types.Enums;
 
 namespace DataGateVPNBot.Handlers;
 
 public partial class TelegramUpdateHandler
 {
+    private const string TelegramAlreadyLinkedToGooglePrefix = "TelegramAlreadyLinkedToGoogle|";
+
     private async Task<Message> CompleteAccountLinkFromBotAsync(
         Message msg,
         string code,
@@ -18,26 +19,39 @@ public partial class TelegramUpdateHandler
         var telegramId = msg.From.Id;
         var result = await authService.CompleteAccountLinkAsync(code, telegramId, cancellationToken);
 
-        var text = result switch
+        string text;
+        if (result is { Success: true, Merge: not null } mergeOk)
         {
-            { Success: true, Merge: not null } mergeOk =>
-                "✅ Аккаунты успешно связаны.\n" +
-                "✅ Accounts linked successfully.\n\n" +
-                $"User #{mergeOk.Merge!.SurvivorUserId}" +
-                (mergeOk.Merge.Warnings.Count > 0
-                    ? "\n\n⚠️ " + string.Join("\n⚠️ ", mergeOk.Merge.Warnings)
-                    : string.Empty),
-            { Success: true } ok =>
-                "✅ " + (string.IsNullOrWhiteSpace(ok.Message)
-                    ? "Accounts linked successfully."
-                    : ok.Message),
-            { Message: var message } when message.Contains("not registered", StringComparison.OrdinalIgnoreCase) =>
-                "❌ " + message + "\n\nИспользуйте /register в боте.\nUse /register in the bot first.",
-            _ =>
-                "❌ " + (string.IsNullOrWhiteSpace(result?.Message)
-                    ? "Could not link accounts. Check the code and try again."
-                    : result!.Message),
-        };
+            text = "✅ " + await GetLocalizationTextAsync(
+                "AccountLinkSuccess",
+                telegramId,
+                new Dictionary<string, string> { ["userId"] = mergeOk.Merge!.SurvivorUserId.ToString() },
+                cancellationToken);
+
+            if (mergeOk.Merge.Warnings.Count > 0)
+                text += "\n\n⚠️ " + string.Join("\n⚠️ ", mergeOk.Merge.Warnings);
+        }
+        else if (result is { Success: true })
+        {
+            text = "✅ " + await GetLocalizationTextAsync("AccountLinkAlreadyLinked", telegramId, cancellationToken);
+        }
+        else if (result?.Message?.StartsWith(TelegramAlreadyLinkedToGooglePrefix, StringComparison.Ordinal) == true)
+        {
+            var label = result.Message[TelegramAlreadyLinkedToGooglePrefix.Length..];
+            text = "❌ " + await GetLocalizationTextAsync(
+                "AccountLinkTelegramAlreadyLinkedToGoogle",
+                telegramId,
+                new Dictionary<string, string> { ["accountLabel"] = label },
+                cancellationToken);
+        }
+        else if (result?.Message?.Contains("not registered", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            text = "❌ " + await GetLocalizationTextAsync("AccountLinkNotRegistered", telegramId, cancellationToken);
+        }
+        else
+        {
+            text = "❌ " + await GetLocalizationTextAsync("AccountLinkFailed", telegramId, cancellationToken);
+        }
 
         return await _botClient.SendMessage(
             msg.Chat,
@@ -50,13 +64,14 @@ public partial class TelegramUpdateHandler
         string? codeArgument,
         CancellationToken cancellationToken)
     {
+        if (msg.From is null)
+            return msg;
+
         if (string.IsNullOrWhiteSpace(codeArgument))
         {
             return await _botClient.SendMessage(
                 msg.Chat,
-                "Введите код из приложения:\n/link_account КОД\n\n" +
-                "Or send the 8-character code alone in this chat.\n\n" +
-                "Enter the code from the app:\n/link_account CODE",
+                await GetLocalizationTextAsync("AccountLinkEnterCodePrompt", msg.From.Id, cancellationToken),
                 cancellationToken: cancellationToken);
         }
 
@@ -64,8 +79,7 @@ public partial class TelegramUpdateHandler
         {
             return await _botClient.SendMessage(
                 msg.Chat,
-                "❌ Неверный формат кода. Нужны 8 символов (A-Z, 2-9).\n" +
-                "❌ Invalid code format. Expected 8 characters (A-Z, 2-9).",
+                "❌ " + await GetLocalizationTextAsync("AccountLinkInvalidCodeFormat", msg.From.Id, cancellationToken),
                 cancellationToken: cancellationToken);
         }
 

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.AccountLink.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.AccountLink.cs
@@ -1,3 +1,4 @@
+using DataGateVPNBot.Helpers;
 using Telegram.Bot;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
@@ -61,25 +62,8 @@ public partial class TelegramUpdateHandler
     }
 
     private static bool TryExtractAccountLinkCode(string messageText, out string code)
-    {
-        code = string.Empty;
-        var trimmed = messageText.Trim();
-        if (trimmed.StartsWith('/'))
-            return false;
-
-        if (trimmed.Length != 8)
-            return false;
-
-        foreach (var ch in trimmed)
-        {
-            if (!IsAccountLinkCodeChar(ch))
-                return false;
-        }
-
-        code = trimmed.ToUpperInvariant();
-        return true;
-    }
+        => AccountLinkCodeParser.TryExtract(messageText, out code);
 
     private static bool IsAccountLinkCodeChar(char ch)
-        => ch is >= 'A' and <= 'Z' or >= '2' and <= '9';
+        => AccountLinkCodeParser.IsCodeChar(ch);
 }

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.AccountLink.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.AccountLink.cs
@@ -1,3 +1,4 @@
+using Telegram.Bot;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.Files.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.Files.cs
@@ -80,6 +80,26 @@ public partial class TelegramUpdateHandler
             cancellationToken: cancellationToken);
     }
 
+    private async Task<Message?> SendVpnAccessDeniedMessageIfNeededAsync(
+        Message msg,
+        string auditContext,
+        IServiceScope scope,
+        CancellationToken cancellationToken)
+    {
+        var gate = await scope.ServiceProvider
+            .GetRequiredService<IFreeTierAccessComplianceBotService>()
+            .EnsureVpnAccessAsync(msg.Chat.Id, auditContext, cancellationToken);
+
+        if (gate.IsAllowed)
+            return null;
+
+        return await _botClient.SendMessage(
+            msg.Chat.Id,
+            gate.UserMessage!,
+            replyMarkup: new ReplyKeyboardRemove(),
+            cancellationToken: cancellationToken);
+    }
+
     private async Task<Message> GetMyFiles(Message msg, string? vpnServerIdArg, CancellationToken cancellationToken)
     {
         await _botClient.SendChatAction(msg.Chat.Id, ChatAction.Typing, cancellationToken: cancellationToken);
@@ -90,6 +110,14 @@ public partial class TelegramUpdateHandler
         }
 
         _logger.LogInformation($"GetMyFiles started for user: {msg.Chat.Id}, ServerId: {vpnServerId}");
+
+        var deniedDownload = await SendVpnAccessDeniedMessageIfNeededAsync(
+            msg,
+            "Download OVPN files",
+            scope,
+            cancellationToken);
+        if (deniedDownload is not null)
+            return deniedDownload;
 
         var isXray = await IsXrayServerAsync(scope, vpnServerId, cancellationToken);
         var mediaGroupOpenVpnFiles = isXray
@@ -129,6 +157,14 @@ public partial class TelegramUpdateHandler
         }
 
         _logger.LogInformation($"GetMyFiles started for user: {msg.Chat.Id}, ServerId: {vpnServerId}");
+
+        var deniedDownloadWithToken = await SendVpnAccessDeniedMessageIfNeededAsync(
+            msg,
+            "Download OVPN files with token",
+            scope,
+            cancellationToken);
+        if (deniedDownloadWithToken is not null)
+            return deniedDownloadWithToken;
 
         var isXray = await IsXrayServerAsync(scope, vpnServerId, cancellationToken);
         if (isXray)
@@ -205,6 +241,14 @@ public partial class TelegramUpdateHandler
                 return await GetOpenVpnServers(msg, BotCommands.CommandMakeNewFile, cancellationToken);
             }
 
+            var denied = await SendVpnAccessDeniedMessageIfNeededAsync(
+                msg,
+                "Create OVPN file",
+                scope,
+                cancellationToken);
+            if (denied is not null)
+                return denied;
+
             var isXray = await IsXrayServerAsync(scope, vpnServerId, cancellationToken);
             var atLimit = isXray
                 ? await scope.ServiceProvider.GetRequiredService<IXrayClientLinkBotService>()
@@ -269,6 +313,14 @@ public partial class TelegramUpdateHandler
             {
                 return await GetOpenVpnServers(msg, BotCommands.CommandMakeNewFileWithToken, cancellationToken);
             }
+
+            var denied = await SendVpnAccessDeniedMessageIfNeededAsync(
+                msg,
+                "Create OVPN file with token",
+                scope,
+                cancellationToken);
+            if (denied is not null)
+                return denied;
 
             var isXray = await IsXrayServerAsync(scope, vpnServerId, cancellationToken);
             var atLimit = isXray

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.Files.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.Files.cs
@@ -86,18 +86,32 @@ public partial class TelegramUpdateHandler
         IServiceScope scope,
         CancellationToken cancellationToken)
     {
-        var gate = await scope.ServiceProvider
-            .GetRequiredService<IFreeTierAccessComplianceBotService>()
-            .EnsureVpnAccessAsync(msg.Chat.Id, auditContext, cancellationToken);
+        var telegramId = msg.From?.Id ?? msg.Chat.Id;
 
-        if (gate.IsAllowed)
-            return null;
+        try
+        {
+            var gate = await scope.ServiceProvider
+                .GetRequiredService<IFreeTierAccessComplianceBotService>()
+                .EnsureVpnAccessAsync(telegramId, auditContext, cancellationToken);
 
-        return await _botClient.SendMessage(
-            msg.Chat.Id,
-            gate.UserMessage!,
-            replyMarkup: new ReplyKeyboardRemove(),
-            cancellationToken: cancellationToken);
+            if (gate.IsAllowed)
+                return null;
+
+            return await _botClient.SendMessage(
+                msg.Chat.Id,
+                gate.UserMessage!,
+                replyMarkup: new ReplyKeyboardRemove(),
+                cancellationToken: cancellationToken);
+        }
+        catch (System.Security.Authentication.AuthenticationException ex)
+        {
+            _logger.LogWarning(ex, "VPN access audit skipped: bot API authentication failed.");
+            return await _botClient.SendMessage(
+                msg.Chat.Id,
+                "Сервис временно недоступен. Попробуйте позже.\nService temporarily unavailable. Please try again later.",
+                replyMarkup: new ReplyKeyboardRemove(),
+                cancellationToken: cancellationToken);
+        }
     }
 
     private async Task<Message> GetMyFiles(Message msg, string? vpnServerIdArg, CancellationToken cancellationToken)

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
@@ -99,6 +99,11 @@ public partial class TelegramUpdateHandler(
 
         await RegisterNewUserAsync(msg, cancellationToken); // optional user registration
 
+        if (isPrivate && TryExtractAccountLinkCode(messageText, out var bareCode))
+        {
+            return await CompleteAccountLinkFromBotAsync(msg, bareCode, cancellationToken);
+        }
+
         var isLocalizationCommand = command is BotCommands.CommandStart
             or BotCommands.CommandChangeLanguage
             or BotCommands.CommandEnglish
@@ -119,6 +124,7 @@ public partial class TelegramUpdateHandler(
         {
             BotCommands.CommandRegister,
             BotCommands.CommandLoginCode,
+            BotCommands.CommandLinkAccount,
             BotCommands.CommandGetMyFiles,
             BotCommands.CommandMakeNewFile,
             BotCommands.CommandMakeNewFileWithToken,
@@ -144,6 +150,7 @@ public partial class TelegramUpdateHandler(
             BotCommands.CommandHowToUse => HowToUseVpn(msg, cancellationToken),
             BotCommands.CommandRegister => RegisterForVpn(msg, cancellationToken),
             BotCommands.CommandLoginCode => SendDashboardLoginCodeAsync(msg, cancellationToken),
+            BotCommands.CommandLinkAccount => LinkAccountCommandAsync(msg, argument, cancellationToken),
             BotCommands.CommandGetMyFiles => GetMyFilesWithToken(msg, argument, cancellationToken),
             BotCommands.CommandGetMyFilesWithToken => GetMyFilesWithToken(msg, argument, cancellationToken),
             BotCommands.CommandGetMyFilesWithoutToken => GetMyFiles(msg, argument, cancellationToken),

--- a/DataGateVPNBot/Helpers/AccountLinkCodeParser.cs
+++ b/DataGateVPNBot/Helpers/AccountLinkCodeParser.cs
@@ -1,0 +1,27 @@
+namespace DataGateVPNBot.Helpers;
+
+public static class AccountLinkCodeParser
+{
+    public static bool TryExtract(string messageText, out string code)
+    {
+        code = string.Empty;
+        var trimmed = messageText.Trim();
+        if (trimmed.StartsWith('/'))
+            return false;
+
+        if (trimmed.Length != 8)
+            return false;
+
+        foreach (var ch in trimmed)
+        {
+            if (!IsCodeChar(ch))
+                return false;
+        }
+
+        code = trimmed.ToUpperInvariant();
+        return true;
+    }
+
+    public static bool IsCodeChar(char ch)
+        => ch is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '2' and <= '9';
+}

--- a/DataGateVPNBot/Helpers/AccountLinkCodeParser.cs
+++ b/DataGateVPNBot/Helpers/AccountLinkCodeParser.cs
@@ -9,19 +9,47 @@ public static class AccountLinkCodeParser
         if (trimmed.StartsWith('/'))
             return false;
 
-        if (trimmed.Length != 8)
+        return TryNormalizeToken(trimmed, out code);
+    }
+
+    public static bool TryNormalizeToken(string? value, out string code)
+    {
+        code = string.Empty;
+        if (string.IsNullOrWhiteSpace(value))
             return false;
 
-        foreach (var ch in trimmed)
+        var token = value.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries)[0];
+        if (token.Length != 8)
+            return false;
+
+        foreach (var ch in token)
         {
             if (!IsCodeChar(ch))
                 return false;
         }
 
-        code = trimmed.ToUpperInvariant();
+        code = token.ToUpperInvariant();
         return true;
     }
 
     public static bool IsCodeChar(char ch)
         => ch is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '2' and <= '9';
+
+    public static string RedactSensitiveMessageText(string? messageText)
+    {
+        if (string.IsNullOrEmpty(messageText))
+            return string.Empty;
+
+        if (TryExtract(messageText, out _))
+            return "[account-link-code-redacted]";
+
+        if (messageText.StartsWith("/link_account", StringComparison.OrdinalIgnoreCase))
+        {
+            var parts = messageText.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length > 1 && TryNormalizeToken(parts[1], out _))
+                return "/link_account [redacted]";
+        }
+
+        return messageText;
+    }
 }

--- a/DataGateVPNBot/Services/BotServices/FreeTierAccessComplianceBotService.cs
+++ b/DataGateVPNBot/Services/BotServices/FreeTierAccessComplianceBotService.cs
@@ -36,13 +36,13 @@ public sealed class FreeTierAccessComplianceBotService(
         return $"{endpoint}{separator}context={Uri.EscapeDataString(context)}";
     }
 
-    public string BuildChannelSubscriptionRequiredMessage()
+    public string BuildAccessDeniedMessage()
     {
         var channel = botOptions.Value.RequiredChannelChatId;
-        return $"У вас не обнаружена подписка на канал {channel}.\n" +
-               $"Подпишитесь на канал и попробуйте снова.\n\n" +
-               $"Channel subscription to {channel} was not detected.\n" +
-               $"Please subscribe and try again.";
+        return $"Для тарифа Free/Default нужна подписка на канал {channel} или связанный аккаунт (Telegram + Google/пароль).\n" +
+               $"Подпишитесь на канал или получите код связки в приложении и отправьте /link_account КОД.\n\n" +
+               $"Free/Default access requires subscription to {channel} or a linked account (Telegram + Google/password).\n" +
+               $"Subscribe to the channel, or request a link code in the app and send /link_account CODE.";
     }
 
     public async Task<bool?> IsSubscribedToRequiredChannelAsync(long telegramId, CancellationToken cancellationToken)
@@ -73,7 +73,7 @@ public sealed class FreeTierAccessComplianceBotService(
         CancellationToken cancellationToken)
     {
         if (telegramId <= 0)
-            return VpnAccessGateResult.Denied(BuildChannelSubscriptionRequiredMessage());
+            return VpnAccessGateResult.Denied(BuildAccessDeniedMessage());
 
         var channelSubscribed = await IsSubscribedToRequiredChannelAsync(telegramId, cancellationToken);
         if (channelSubscribed == true)
@@ -108,7 +108,7 @@ public sealed class FreeTierAccessComplianceBotService(
                 response?.Message);
         }
 
-        return VpnAccessGateResult.Denied(BuildChannelSubscriptionRequiredMessage());
+        return VpnAccessGateResult.Denied(BuildAccessDeniedMessage());
     }
 
     public static bool IsActiveMember(ChatMember member)

--- a/DataGateVPNBot/Services/BotServices/FreeTierAccessComplianceBotService.cs
+++ b/DataGateVPNBot/Services/BotServices/FreeTierAccessComplianceBotService.cs
@@ -1,0 +1,121 @@
+using System.Security.Authentication;
+using DataGateVPNBot.Models.Configurations;
+using DataGateVPNBot.Services.BotServices.Interfaces;
+using DataGateVPNBot.Services.DashboardServices;
+using DataGateVPNBot.Services.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+
+namespace DataGateVPNBot.Services.BotServices;
+
+public sealed class FreeTierAccessComplianceBotService(
+    ITelegramBotClient botClient,
+    IOptions<BotConfiguration> botOptions,
+    AuthService authService,
+    IHttpRequestService httpRequestService,
+    ILogger<FreeTierAccessComplianceBotService> logger) : IFreeTierAccessComplianceBotService
+{
+    private const string AuditEndpointPrefix = "api/users/audit-free-tier-access/by-telegram/";
+
+    public static string BuildAuditEndpoint(long telegramId, bool? channelSubscribed, string? context = null)
+    {
+        var endpoint = channelSubscribed switch
+        {
+            true => $"{AuditEndpointPrefix}{telegramId}?channelSubscribed=true",
+            false => $"{AuditEndpointPrefix}{telegramId}?channelSubscribed=false",
+            _ => $"{AuditEndpointPrefix}{telegramId}",
+        };
+
+        if (string.IsNullOrWhiteSpace(context))
+            return endpoint;
+
+        var separator = endpoint.Contains('?', StringComparison.Ordinal) ? '&' : '?';
+        return $"{endpoint}{separator}context={Uri.EscapeDataString(context)}";
+    }
+
+    public string BuildChannelSubscriptionRequiredMessage()
+    {
+        var channel = botOptions.Value.RequiredChannelChatId;
+        return $"У вас не обнаружена подписка на канал {channel}.\n" +
+               $"Подпишитесь на канал и попробуйте снова.\n\n" +
+               $"Channel subscription to {channel} was not detected.\n" +
+               $"Please subscribe and try again.";
+    }
+
+    public async Task<bool?> IsSubscribedToRequiredChannelAsync(long telegramId, CancellationToken cancellationToken)
+    {
+        if (telegramId <= 0)
+            return false;
+
+        try
+        {
+            var chatId = new ChatId(botOptions.Value.RequiredChannelChatId);
+            var member = await botClient.GetChatMember(chatId, telegramId, cancellationToken);
+            return IsActiveMember(member);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to verify channel subscription for Telegram user {TelegramId} in {Channel}",
+                telegramId,
+                botOptions.Value.RequiredChannelChatId);
+            return null;
+        }
+    }
+
+    public async Task<VpnAccessGateResult> EnsureVpnAccessAsync(
+        long telegramId,
+        string context,
+        CancellationToken cancellationToken)
+    {
+        if (telegramId <= 0)
+            return VpnAccessGateResult.Denied(BuildChannelSubscriptionRequiredMessage());
+
+        var channelSubscribed = await IsSubscribedToRequiredChannelAsync(telegramId, cancellationToken);
+        if (channelSubscribed == true)
+            return VpnAccessGateResult.Allowed;
+
+        var token = await authService.GetTokenAsync();
+        if (string.IsNullOrEmpty(token))
+            throw new AuthenticationException("Authentication failed. Failed to obtain a valid token from API.");
+
+        var endpoint = BuildAuditEndpoint(telegramId, channelSubscribed, context);
+
+        logger.LogInformation(
+            "Checking VPN access for TelegramId={TelegramId}, ChannelSubscribed={ChannelSubscribed}, Context={Context}",
+            telegramId,
+            channelSubscribed,
+            context);
+
+        var response = await httpRequestService.PostAsync<DataGateMonitor.SharedModels.Responses.ApiResponse<bool>>(
+            endpoint,
+            new { },
+            token,
+            cancellationToken);
+
+        if (response is { Success: true, Data: true })
+            return VpnAccessGateResult.Allowed;
+
+        if (response is not { Success: true })
+        {
+            logger.LogWarning(
+                "VPN access audit request failed for TelegramId={TelegramId}: {Message}",
+                telegramId,
+                response?.Message);
+        }
+
+        return VpnAccessGateResult.Denied(BuildChannelSubscriptionRequiredMessage());
+    }
+
+    public static bool IsActiveMember(ChatMember member)
+        => member.Status switch
+        {
+            ChatMemberStatus.Creator or ChatMemberStatus.Administrator or ChatMemberStatus.Member
+                or ChatMemberStatus.Restricted => true,
+            _ => false,
+        };
+}

--- a/DataGateVPNBot/Services/BotServices/IncomingMessageLogService.cs
+++ b/DataGateVPNBot/Services/BotServices/IncomingMessageLogService.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using DataGateVPNBot.Helpers;
 using DataGateVPNBot.Services.BotServices.Interfaces;
 using DataGateVPNBot.Services.DashboardServices.Interfaces;
 using DataGateVPNBot.Services.Interfaces;
@@ -22,7 +23,7 @@ public class IncomingMessageLogService(IIncomingMessageLogSenderService incoming
                 Username = msg.From?.Username,
                 FirstName = msg.From?.FirstName,
                 LastName = msg.From?.LastName,
-                MessageText = msg.Text ?? string.Empty,
+                MessageText = AccountLinkCodeParser.RedactSensitiveMessageText(msg.Text),
                 ReceivedAt = DateTime.UtcNow
             }
         };

--- a/DataGateVPNBot/Services/BotServices/Interfaces/IFreeTierAccessComplianceBotService.cs
+++ b/DataGateVPNBot/Services/BotServices/Interfaces/IFreeTierAccessComplianceBotService.cs
@@ -1,0 +1,14 @@
+using DataGateVPNBot.Services.BotServices;
+
+namespace DataGateVPNBot.Services.BotServices.Interfaces;
+
+public interface IFreeTierAccessComplianceBotService
+{
+    Task<bool?> IsSubscribedToRequiredChannelAsync(long telegramId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// For Free/Default plans: requires merged Telegram+Google account or channel subscription.
+    /// Notifies admins when access is denied. Returns a user-facing message when blocked.
+    /// </summary>
+    Task<VpnAccessGateResult> EnsureVpnAccessAsync(long telegramId, string context, CancellationToken cancellationToken);
+}

--- a/DataGateVPNBot/Services/BotServices/TelegramSettingsService.cs
+++ b/DataGateVPNBot/Services/BotServices/TelegramSettingsService.cs
@@ -112,6 +112,16 @@ public class TelegramSettingsService : ITelegramSettingsService
         },
         new()
         {
+            Command = BotCommands.CommandLinkAccount,
+            Descriptions = new()
+            {
+                ["en"] = "Link your app account using a code from the client",
+                ["ru"] = "Привязать аккаунт приложения кодом из клиента",
+                ["el"] = "Σύνδεση λογαριασμού εφαρμογής με κωδικό από τον client"
+            }
+        },
+        new()
+        {
             Command = BotCommands.CommandRefreshProfilePhotos,
             Descriptions = new()
             {

--- a/DataGateVPNBot/Services/BotServices/VpnAccessGateResult.cs
+++ b/DataGateVPNBot/Services/BotServices/VpnAccessGateResult.cs
@@ -1,0 +1,13 @@
+namespace DataGateVPNBot.Services.BotServices;
+
+public sealed class VpnAccessGateResult
+{
+    public bool IsAllowed { get; init; }
+
+    public string? UserMessage { get; init; }
+
+    public static VpnAccessGateResult Allowed { get; } = new() { IsAllowed = true };
+
+    public static VpnAccessGateResult Denied(string userMessage) =>
+        new() { IsAllowed = false, UserMessage = userMessage };
+}

--- a/DataGateVPNBot/Services/DashboardServices/AuthService.cs
+++ b/DataGateVPNBot/Services/DashboardServices/AuthService.cs
@@ -1,6 +1,8 @@
 using DataGateVPNBot.Services.Http;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+using DataGateMonitor.SharedModels.DataGateMonitor.User.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.User.Responses;
 using DataGateMonitor.SharedModels.Responses;
 
 namespace DataGateVPNBot.Services.DashboardServices;
@@ -105,6 +107,58 @@ public class AuthService(
         {
             logger.LogError(ex, "Failed to request dashboard login code for TelegramId {TelegramId}", telegramId);
             return null;
+        }
+    }
+
+    public async Task<CompleteTelegramAccountLinkResponse?> CompleteAccountLinkAsync(
+        string code,
+        long telegramId,
+        CancellationToken ct = default)
+    {
+        var token = await GetTokenAsync();
+        if (string.IsNullOrEmpty(token))
+        {
+            logger.LogWarning("Cannot complete account link: App token unavailable.");
+            return null;
+        }
+
+        var body = new CompleteTelegramAccountLinkRequest
+        {
+            Code = code.Trim(),
+            TelegramId = telegramId,
+        };
+
+        try
+        {
+            var response = await httpRequestService.PostAsync<ApiResponse<CompleteTelegramAccountLinkResponse>>(
+                "api/users/merge-telegram-google/by-link-code",
+                body,
+                token,
+                ct);
+
+            if (response is not { Success: true, Data: not null })
+            {
+                logger.LogWarning(
+                    "Account link failed for TelegramId {TelegramId}: {Message}",
+                    telegramId,
+                    response?.Message);
+                return response?.Data ?? new CompleteTelegramAccountLinkResponse
+                {
+                    Success = false,
+                    Message = response?.Message ?? "Account link request failed.",
+                };
+            }
+
+            return response.Data;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to complete account link for TelegramId {TelegramId}", telegramId);
+            return new CompleteTelegramAccountLinkResponse
+            {
+                Success = false,
+                Message = "Could not reach the server. Try again later.",
+            };
         }
     }
 }

--- a/DataGateVPNBot/Services/DashboardServices/TelegramBotUserService.cs
+++ b/DataGateVPNBot/Services/DashboardServices/TelegramBotUserService.cs
@@ -87,8 +87,16 @@ public class TelegramBotUserService(
                 return true;
             }
 
-            logger.LogWarning("UserExistsAsync: user {TelegramUserId} does not exist or API returned error. Message: {Message}",
-                telegramUserId, response?.Message);
+            if (response is { Success: true, Data: false })
+            {
+                logger.LogDebug("UserExistsAsync: user {TelegramUserId} not registered yet.", telegramUserId);
+                return false;
+            }
+
+            logger.LogWarning(
+                "UserExistsAsync: API error while checking user {TelegramUserId}. Message: {Message}",
+                telegramUserId,
+                response?.Message ?? "null response");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- Account link by code and free-tier VPN access gate in the bot
- Localized account-link bot messages via dashboard LocalizationTexts
- Hardened bot account link and VPN gate based on review feedback

## Test plan
- [x] Added account link parser tests and AuthService link coverage
- [ ] Manual: verify `/link_account CODE` flow end-to-end against the deployed backend