### PR TITLE
Unsubscribed VPN digest, channel access copy, and remind buttons

### DIFF
--- a/DataGateVPNBot.Models/Configurations/BotConfiguration.cs
+++ b/DataGateVPNBot.Models/Configurations/BotConfiguration.cs
@@ -17,4 +17,7 @@ public class BotConfiguration
 
     public string RequiredChannelChatId =>
         $"@{RequiredChannelUsername.Trim().TrimStart('@')}";
+
+    public string RequiredChannelUrl =>
+        $"https://t.me/{RequiredChannelUsername.Trim().TrimStart('@')}";
 }

--- a/DataGateVPNBot.Models/DataGateVPNBot.Models.csproj
+++ b/DataGateVPNBot.Models/DataGateVPNBot.Models.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Telegram.Bot" Version="22.10.1" />
+      <PackageReference Include="Telegram.Bot" Version="22.10.2.1" />
     </ItemGroup>
 
 </Project>

--- a/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
+++ b/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <!-- SharedModels: NuGet only (never ProjectReference). -->
-    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.35" />
+    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataGateVPNBot\DataGateVPNBot.csproj" />

--- a/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
+++ b/DataGateVPNBot.Tests/DataGateVPNBot.Tests.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <!-- SharedModels: NuGet only (never ProjectReference). -->
-    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
+    <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.50" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DataGateVPNBot\DataGateVPNBot.csproj" />

--- a/DataGateVPNBot.Tests/Localization/ApiErrorMessageMapperTests.cs
+++ b/DataGateVPNBot.Tests/Localization/ApiErrorMessageMapperTests.cs
@@ -1,0 +1,90 @@
+using DataGateVPNBot.Localization;
+using Xunit;
+
+namespace DataGateVPNBot.Tests.Localization;
+
+public class ApiErrorMessageMapperTests
+{
+    [Fact]
+    public void TryMap_TelegramAlreadyLinkedToGoogle_extracts_account_label()
+    {
+        var ok = ApiErrorMessageMapper.TryMap(
+            "TelegramAlreadyLinkedToGoogle|koz_nik (25052001kozin@gmail.com)",
+            out var mapped);
+
+        Assert.True(ok);
+        Assert.Equal(
+            ApiErrorMessageMapper.LocalizationAccountLinkTelegramAlreadyLinkedToGoogle,
+            mapped.LocalizationKey);
+        Assert.True(mapped.IsExpectedBusinessError);
+        Assert.Equal("koz_nik (25052001kozin@gmail.com)", mapped.Placeholders!["accountLabel"]);
+    }
+
+    [Fact]
+    public void TryMap_VpnServerNotAllowedByQuotaPlan_key()
+    {
+        var ok = ApiErrorMessageMapper.TryMap(
+            ApiErrorMessageMapper.VpnServerNotAllowedByQuotaPlanKey,
+            out var mapped);
+
+        Assert.True(ok);
+        Assert.Equal(ApiErrorMessageMapper.LocalizationVpnServerNotAllowedByQuotaPlan, mapped.LocalizationKey);
+        Assert.True(mapped.IsExpectedBusinessError);
+        Assert.Null(mapped.Placeholders);
+    }
+
+    [Fact]
+    public void TryMap_legacy_quota_plan_english_message()
+    {
+        var ok = ApiErrorMessageMapper.TryMap(
+            "VPN server 77 is not allowed for user 293's active quota plan 2.",
+            out var mapped);
+
+        Assert.True(ok);
+        Assert.Equal(ApiErrorMessageMapper.LocalizationVpnServerNotAllowedByQuotaPlan, mapped.LocalizationKey);
+    }
+
+    [Fact]
+    public void ExtractPrimaryMessage_from_retried_http_error_notification_body()
+    {
+        const string raw =
+            """
+            Failed to complete HTTP request to api/open-vpn-files/add-with-token after 3 attempts.
+            Attempt 1: BadRequest - Bad Request
+            Response body: {"success":false,"message":"VPN server 77 is not allowed for user 293's active quota plan 2.","data":null}
+            Attempt 2: BadRequest - Bad Request
+            Response body: {"success":false,"message":"VPN server 77 is not allowed for user 293's active quota plan 2.","data":null}
+            Attempt 3: BadRequest - Bad Request
+            Response body: {"success":false,"message":"VPN server 77 is not allowed for user 293's active quota plan 2.","data":null}
+            """;
+
+        var message = ApiErrorMessageMapper.ExtractPrimaryMessage(raw);
+
+        Assert.Equal("VPN server 77 is not allowed for user 293's active quota plan 2.", message);
+        Assert.True(ApiErrorMessageMapper.TryMap(raw, out var mapped));
+        Assert.Equal(ApiErrorMessageMapper.LocalizationVpnServerNotAllowedByQuotaPlan, mapped.LocalizationKey);
+    }
+
+    [Fact]
+    public void ExtractPrimaryMessage_from_account_link_http_error_body()
+    {
+        const string raw =
+            """
+            Failed to complete HTTP request to api/users/merge-telegram-google/by-link-code after 3 attempts.
+            Attempt 1: BadRequest - Bad Request
+            Response body: {"success":false,"message":"TelegramAlreadyLinkedToGoogle|koz_nik (25052001kozin@gmail.com)","data":null}
+            """;
+
+        Assert.True(ApiErrorMessageMapper.TryMap(raw, out var mapped));
+        Assert.Equal(
+            ApiErrorMessageMapper.LocalizationAccountLinkTelegramAlreadyLinkedToGoogle,
+            mapped.LocalizationKey);
+        Assert.Equal("koz_nik (25052001kozin@gmail.com)", mapped.Placeholders!["accountLabel"]);
+    }
+
+    [Fact]
+    public void TryMap_returns_false_for_unknown_message()
+    {
+        Assert.False(ApiErrorMessageMapper.TryMap("Something unexpected exploded", out _));
+    }
+}

--- a/DataGateVPNBot.Tests/Services/AuthServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/AuthServiceTests.cs
@@ -121,4 +121,66 @@ public class AuthServiceTests
         Assert.NotNull(result);
         Assert.True(result!.Success);
     }
+
+    [Fact]
+    public async Task CompleteAccountLinkAsync_Returns_Keyed_Message_WhenApiReturns_BadRequest_Body()
+    {
+        var httpRequest = new Mock<IHttpRequestService>();
+        httpRequest.Setup(h => h.PostAsync<ApiResponse<TokenResponse>>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<TokenResponse>
+            {
+                Success = true,
+                Data = new TokenResponse { Token = "jwt", Expiration = DateTimeOffset.UtcNow.AddHours(1) },
+            });
+        httpRequest.Setup(h => h.PostAsync<ApiResponse<CompleteTelegramAccountLinkResponse>>(
+                "api/users/merge-telegram-google/by-link-code",
+                It.IsAny<object>(),
+                "jwt",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<CompleteTelegramAccountLinkResponse>
+            {
+                Success = false,
+                Message = "TelegramAlreadyLinkedToGoogle|koz_nik (a@b.c)",
+                Data = null,
+            });
+
+        var sut = new AuthService(httpRequest.Object, "clientId", "secret", Mock.Of<ILogger<AuthService>>());
+
+        var result = await sut.CompleteAccountLinkAsync("ABCD2345", 12345, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.False(result!.Success);
+        Assert.Equal("TelegramAlreadyLinkedToGoogle|koz_nik (a@b.c)", result.Message);
+    }
+
+    [Fact]
+    public async Task CompleteAccountLinkAsync_Extracts_Keyed_Message_From_HttpRequestException()
+    {
+        var httpRequest = new Mock<IHttpRequestService>();
+        httpRequest.Setup(h => h.PostAsync<ApiResponse<TokenResponse>>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<TokenResponse>
+            {
+                Success = true,
+                Data = new TokenResponse { Token = "jwt", Expiration = DateTimeOffset.UtcNow.AddHours(1) },
+            });
+        httpRequest.Setup(h => h.PostAsync<ApiResponse<CompleteTelegramAccountLinkResponse>>(
+                "api/users/merge-telegram-google/by-link-code",
+                It.IsAny<object>(),
+                "jwt",
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException(
+                """
+                Failed to complete HTTP request to api/users/merge-telegram-google/by-link-code after 3 attempts.
+                Attempt 1: BadRequest - Bad Request
+                Response body: {"success":false,"message":"TelegramAlreadyLinkedToGoogle|koz_nik (a@b.c)","data":null}
+                """));
+
+        var sut = new AuthService(httpRequest.Object, "clientId", "secret", Mock.Of<ILogger<AuthService>>());
+
+        var result = await sut.CompleteAccountLinkAsync("ABCD2345", 12345, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.False(result!.Success);
+        Assert.Equal("TelegramAlreadyLinkedToGoogle|koz_nik (a@b.c)", result.Message);
+    }
 }

--- a/DataGateVPNBot.Tests/Services/FreeTierAccessComplianceBotServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/FreeTierAccessComplianceBotServiceTests.cs
@@ -1,4 +1,7 @@
 using DataGateVPNBot.Services.BotServices;
+using DataGateVPNBot.Services.DashboardServices.Interfaces;
+using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotLocalization.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotLocalization.Responses;
 using Moq;
 using Telegram.Bot.Types;
 using Xunit;
@@ -29,26 +32,46 @@ public class FreeTierAccessComplianceBotServiceTests
     }
 
     [Fact]
-    public void BuildAccessDeniedMessage_RequiresChannelSubscriptionOnly()
+    public async Task BuildAccessDeniedMessageAsync_AppliesLocalizationPlaceholders()
     {
+        var localization = new Mock<ILocalizationService>();
+        localization.Setup(l => l.GetTextForTelegramUser(
+                It.Is<GetTextForTelegramUserRequest>(r =>
+                    r.Key == FreeTierAccessComplianceBotService.AccessDeniedLocalizationKey &&
+                    r.TelegramId == 42),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetTextForTelegramUserResponse
+            {
+                Text = "Need {channel}\n{channelUrl}",
+            });
+
         var service = new FreeTierAccessComplianceBotService(
             Mock.Of<Telegram.Bot.ITelegramBotClient>(),
             Microsoft.Extensions.Options.Options.Create(
                 new DataGateVPNBot.Models.Configurations.BotConfiguration
                 {
-                    RequiredChannelUsername = "DataGateVPNBot",
+                    RequiredChannelUsername = "datagateapp",
                 }),
             null!,
             null!,
+            localization.Object,
             Mock.Of<Microsoft.Extensions.Logging.ILogger<FreeTierAccessComplianceBotService>>());
 
-        var message = service.BuildAccessDeniedMessage();
+        var message = await service.BuildAccessDeniedMessageAsync(42, CancellationToken.None);
 
-        Assert.Contains("@DataGateVPNBot", message);
-        Assert.DoesNotContain("/link_account", message);
-        Assert.DoesNotContain("linked account", message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("subscription", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("Need @datagateapp\nhttps://t.me/datagateapp", message);
+        Assert.DoesNotContain("Для тарифа", message);
+        Assert.DoesNotContain("Free/Default access requires", message);
     }
+
+    [Theory]
+    [InlineData("Bad Request: PARTICIPANT_ID_INVALID", true)]
+    [InlineData("Bad Request: user not found", true)]
+    [InlineData("Forbidden: bot is not a member of the channel chat", false)]
+    public void IsExpectedNonMembershipError_ClassifiesMessages(string message, bool expected)
+        => Assert.Equal(
+            expected,
+            FreeTierAccessComplianceBotService.IsExpectedNonMembershipError(new Exception(message)));
 
     [Fact]
     public void VpnAccessGateResult_Denied_CarriesUserMessage()

--- a/DataGateVPNBot.Tests/Services/FreeTierAccessComplianceBotServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/FreeTierAccessComplianceBotServiceTests.cs
@@ -29,7 +29,7 @@ public class FreeTierAccessComplianceBotServiceTests
     }
 
     [Fact]
-    public void BuildAccessDeniedMessage_IncludesChannelAndLinkAccountHint()
+    public void BuildAccessDeniedMessage_RequiresChannelSubscriptionOnly()
     {
         var service = new FreeTierAccessComplianceBotService(
             Mock.Of<Telegram.Bot.ITelegramBotClient>(),
@@ -45,8 +45,9 @@ public class FreeTierAccessComplianceBotServiceTests
         var message = service.BuildAccessDeniedMessage();
 
         Assert.Contains("@DataGateVPNBot", message);
-        Assert.Contains("/link_account", message);
-        Assert.Contains("linked account", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("/link_account", message);
+        Assert.DoesNotContain("linked account", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("subscription", message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/DataGateVPNBot.Tests/Services/FreeTierChannelSubscribeRemindBotServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/FreeTierChannelSubscribeRemindBotServiceTests.cs
@@ -1,0 +1,154 @@
+using System.Security.Authentication;
+using DataGateVPNBot.Services.BotServices;
+using DataGateVPNBot.Services.DashboardServices;
+using DataGateVPNBot.Services.Http;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Enums;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace DataGateVPNBot.Tests.Services;
+
+public class FreeTierChannelSubscribeRemindBotServiceTests
+{
+    [Fact]
+    public async Task RemindAsync_WhenTargetEmpty_ReturnsUsage()
+    {
+        var sut = new FreeTierChannelSubscribeRemindBotService(
+            new AuthService(Mock.Of<IHttpRequestService>(), "c", "s", Mock.Of<ILogger<AuthService>>()),
+            Mock.Of<IHttpRequestService>(MockBehavior.Strict),
+            Mock.Of<ILogger<FreeTierChannelSubscribeRemindBotService>>());
+
+        var result = await sut.RemindAsync(
+            "  ",
+            FreeTierChannelSubscribeRemindChannel.Telegram,
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.StartsWith("Usage:", result.Message);
+    }
+
+    [Fact]
+    public async Task RemindAsync_PostsChannelQuery_Telegram()
+    {
+        var http = new Mock<IHttpRequestService>();
+        http.Setup(h => h.PostAsync<ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>>(
+                It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>
+            {
+                Success = true,
+                Data = new DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse { Token = "t" },
+            });
+        http.Setup(h => h.PostAsync<ApiResponse<FreeTierChannelSubscribeRemindResponse>>(
+                "api/free-tier-enforcement/remind-channel-subscribe/22?channel=Telegram",
+                It.IsAny<object>(),
+                "t",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<FreeTierChannelSubscribeRemindResponse>
+            {
+                Success = true,
+                Data = FreeTierChannelSubscribeRemindResponse.Ok(
+                    FreeTierChannelSubscribeRemindChannel.Telegram,
+                    "✅ Reminder sent",
+                    telegramId: 22),
+            });
+
+        var auth = new AuthService(http.Object, "c", "s", Mock.Of<ILogger<AuthService>>());
+        var sut = new FreeTierChannelSubscribeRemindBotService(
+            auth, http.Object, Mock.Of<ILogger<FreeTierChannelSubscribeRemindBotService>>());
+
+        var result = await sut.RemindAsync("22", FreeTierChannelSubscribeRemindChannel.Telegram, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Equal("✅ Reminder sent", result.Message);
+    }
+
+    [Fact]
+    public async Task RemindAsync_PostsChannelQuery_Email()
+    {
+        var http = new Mock<IHttpRequestService>();
+        http.Setup(h => h.PostAsync<ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>>(
+                It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>
+            {
+                Success = true,
+                Data = new DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse { Token = "t" },
+            });
+        http.Setup(h => h.PostAsync<ApiResponse<FreeTierChannelSubscribeRemindResponse>>(
+                "api/free-tier-enforcement/remind-channel-subscribe/150?channel=Email",
+                It.IsAny<object>(),
+                "t",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<FreeTierChannelSubscribeRemindResponse>
+            {
+                Success = true,
+                Data = FreeTierChannelSubscribeRemindResponse.Ok(
+                    FreeTierChannelSubscribeRemindChannel.Email,
+                    "✅ Email sent",
+                    userId: 150,
+                    email: "a@b.c"),
+            });
+
+        var auth = new AuthService(http.Object, "c", "s", Mock.Of<ILogger<AuthService>>());
+        var sut = new FreeTierChannelSubscribeRemindBotService(
+            auth, http.Object, Mock.Of<ILogger<FreeTierChannelSubscribeRemindBotService>>());
+
+        var result = await sut.RemindAsync("150", FreeTierChannelSubscribeRemindChannel.Email, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Equal("a@b.c", result.Email);
+    }
+
+    [Fact]
+    public async Task RemindAsync_WhenApiFails_ReturnsFailMessage()
+    {
+        var http = new Mock<IHttpRequestService>();
+        http.Setup(h => h.PostAsync<ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>>(
+                It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>
+            {
+                Success = true,
+                Data = new DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse { Token = "t" },
+            });
+        http.Setup(h => h.PostAsync<ApiResponse<FreeTierChannelSubscribeRemindResponse>>(
+                It.IsAny<string>(),
+                It.IsAny<object>(),
+                "t",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<FreeTierChannelSubscribeRemindResponse>
+            {
+                Success = false,
+                Message = "User has no email",
+            });
+
+        var auth = new AuthService(http.Object, "c", "s", Mock.Of<ILogger<AuthService>>());
+        var sut = new FreeTierChannelSubscribeRemindBotService(
+            auth, http.Object, Mock.Of<ILogger<FreeTierChannelSubscribeRemindBotService>>());
+
+        var result = await sut.RemindAsync("7", FreeTierChannelSubscribeRemindChannel.Email, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal("User has no email", result.Message);
+    }
+
+    [Fact]
+    public async Task RemindAsync_Throws_WhenNoToken()
+    {
+        var http = new Mock<IHttpRequestService>();
+        http.Setup(h => h.PostAsync<ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>>(
+                It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>
+            {
+                Success = false,
+            });
+
+        var auth = new AuthService(http.Object, "c", "s", Mock.Of<ILogger<AuthService>>());
+        var sut = new FreeTierChannelSubscribeRemindBotService(
+            auth, http.Object, Mock.Of<ILogger<FreeTierChannelSubscribeRemindBotService>>());
+
+        await Assert.ThrowsAsync<AuthenticationException>(() =>
+            sut.RemindAsync("22", FreeTierChannelSubscribeRemindChannel.Telegram, CancellationToken.None));
+    }
+}

--- a/DataGateVPNBot.Tests/Services/FreeTierUnsubscribedVpnDigestBotServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/FreeTierUnsubscribedVpnDigestBotServiceTests.cs
@@ -2,6 +2,9 @@ using System.Security.Authentication;
 using DataGateVPNBot.Services.BotServices;
 using DataGateVPNBot.Services.DashboardServices;
 using DataGateVPNBot.Services.Http;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Enums;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
 using DataGateMonitor.SharedModels.Responses;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -12,7 +15,7 @@ namespace DataGateVPNBot.Tests.Services;
 public class FreeTierUnsubscribedVpnDigestBotServiceTests
 {
     [Fact]
-    public async Task GetDigestTextAsync_ReturnsData_WhenApiSucceeds()
+    public async Task GetDigestAsync_ReturnsStructuredData_WhenApiSucceeds()
     {
         var http = new Mock<IHttpRequestService>();
         http.Setup(h => h.PostAsync<ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>>(
@@ -22,21 +25,36 @@ public class FreeTierUnsubscribedVpnDigestBotServiceTests
                 Success = true,
                 Data = new DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse { Token = "t" },
             });
-        http.Setup(h => h.GetAsync<ApiResponse<string>>(
+        http.Setup(h => h.GetAsync<ApiResponse<FreeTierUnsubscribedVpnDigestResponse>>(
                 "api/free-tier-enforcement/unsubscribed-vpn-digest", "t", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ApiResponse<string> { Success = true, Data = "digest-text" });
+            .ReturnsAsync(new ApiResponse<FreeTierUnsubscribedVpnDigestResponse>
+            {
+                Success = true,
+                Data = new FreeTierUnsubscribedVpnDigestResponse
+                {
+                    Text = "digest-text",
+                    Candidates =
+                    [
+                        new FreeTierEnforcementCandidateDto { UserId = 150, Email = "a@b.c" },
+                        new FreeTierEnforcementCandidateDto { UserId = 7, Email = null },
+                    ],
+                },
+            });
 
         var auth = new AuthService(http.Object, "c", "s", Mock.Of<ILogger<AuthService>>());
         var sut = new FreeTierUnsubscribedVpnDigestBotService(
             auth, http.Object, Mock.Of<ILogger<FreeTierUnsubscribedVpnDigestBotService>>());
 
-        var text = await sut.GetDigestTextAsync(CancellationToken.None);
+        var digest = await sut.GetDigestAsync(CancellationToken.None);
 
-        Assert.Equal("digest-text", text);
+        Assert.NotNull(digest);
+        Assert.Equal("digest-text", digest!.Text);
+        Assert.Equal(2, digest.Candidates.Count);
+        Assert.Equal("a@b.c", digest.Candidates[0].Email);
     }
 
     [Fact]
-    public async Task GetDigestTextAsync_Throws_WhenNoToken()
+    public async Task GetDigestAsync_Throws_WhenNoToken()
     {
         var http = new Mock<IHttpRequestService>();
         http.Setup(h => h.PostAsync<ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>>(
@@ -50,6 +68,38 @@ public class FreeTierUnsubscribedVpnDigestBotServiceTests
         var sut = new FreeTierUnsubscribedVpnDigestBotService(
             auth, http.Object, Mock.Of<ILogger<FreeTierUnsubscribedVpnDigestBotService>>());
 
-        await Assert.ThrowsAsync<AuthenticationException>(() => sut.GetDigestTextAsync(CancellationToken.None));
+        await Assert.ThrowsAsync<AuthenticationException>(() => sut.GetDigestAsync(CancellationToken.None));
+    }
+}
+
+public class FreeTierEmailRemindKeyboardTests
+{
+    [Fact]
+    public void BuildEmailRemindKeyboard_OnlyCandidatesWithEmail()
+    {
+        var keyboard = DataGateVPNBot.Handlers.TelegramUpdateHandler.BuildEmailRemindKeyboard(
+        [
+            new FreeTierEnforcementCandidateDto { UserId = 150, DisplayName = "A", Email = "a@x.com" },
+            new FreeTierEnforcementCandidateDto { UserId = 7, DisplayName = "B", Email = null },
+            new FreeTierEnforcementCandidateDto { UserId = 9, DisplayName = "C", Email = "  " },
+            new FreeTierEnforcementCandidateDto { UserId = 3, DisplayName = "D", Email = "d@x.com" },
+        ]);
+
+        Assert.NotNull(keyboard);
+        var buttons = keyboard!.InlineKeyboard.SelectMany(r => r).ToList();
+        Assert.Equal(2, buttons.Count);
+        Assert.Contains(buttons, b => b.Text == "Email #150" && b.CallbackData == "/remind_channel_email 150");
+        Assert.Contains(buttons, b => b.Text == "Email #3" && b.CallbackData == "/remind_channel_email 3");
+    }
+
+    [Fact]
+    public void BuildEmailRemindKeyboard_ReturnsNull_WhenNoEmails()
+    {
+        var keyboard = DataGateVPNBot.Handlers.TelegramUpdateHandler.BuildEmailRemindKeyboard(
+        [
+            new FreeTierEnforcementCandidateDto { UserId = 1, Email = null },
+        ]);
+
+        Assert.Null(keyboard);
     }
 }

--- a/DataGateVPNBot.Tests/Services/FreeTierUnsubscribedVpnDigestBotServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/FreeTierUnsubscribedVpnDigestBotServiceTests.cs
@@ -1,0 +1,55 @@
+using System.Security.Authentication;
+using DataGateVPNBot.Services.BotServices;
+using DataGateVPNBot.Services.DashboardServices;
+using DataGateVPNBot.Services.Http;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace DataGateVPNBot.Tests.Services;
+
+public class FreeTierUnsubscribedVpnDigestBotServiceTests
+{
+    [Fact]
+    public async Task GetDigestTextAsync_ReturnsData_WhenApiSucceeds()
+    {
+        var http = new Mock<IHttpRequestService>();
+        http.Setup(h => h.PostAsync<ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>>(
+                It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>
+            {
+                Success = true,
+                Data = new DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse { Token = "t" },
+            });
+        http.Setup(h => h.GetAsync<ApiResponse<string>>(
+                "api/free-tier-enforcement/unsubscribed-vpn-digest", "t", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<string> { Success = true, Data = "digest-text" });
+
+        var auth = new AuthService(http.Object, "c", "s", Mock.Of<ILogger<AuthService>>());
+        var sut = new FreeTierUnsubscribedVpnDigestBotService(
+            auth, http.Object, Mock.Of<ILogger<FreeTierUnsubscribedVpnDigestBotService>>());
+
+        var text = await sut.GetDigestTextAsync(CancellationToken.None);
+
+        Assert.Equal("digest-text", text);
+    }
+
+    [Fact]
+    public async Task GetDigestTextAsync_Throws_WhenNoToken()
+    {
+        var http = new Mock<IHttpRequestService>();
+        http.Setup(h => h.PostAsync<ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>>(
+                It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>
+            {
+                Success = false,
+            });
+
+        var auth = new AuthService(http.Object, "c", "s", Mock.Of<ILogger<AuthService>>());
+        var sut = new FreeTierUnsubscribedVpnDigestBotService(
+            auth, http.Object, Mock.Of<ILogger<FreeTierUnsubscribedVpnDigestBotService>>());
+
+        await Assert.ThrowsAsync<AuthenticationException>(() => sut.GetDigestTextAsync(CancellationToken.None));
+    }
+}

--- a/DataGateVPNBot.Tests/Services/FreeTierUnsubscribedVpnDigestBotServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/FreeTierUnsubscribedVpnDigestBotServiceTests.cs
@@ -3,7 +3,6 @@ using DataGateVPNBot.Services.BotServices;
 using DataGateVPNBot.Services.DashboardServices;
 using DataGateVPNBot.Services.Http;
 using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Dto;
-using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Enums;
 using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
 using DataGateMonitor.SharedModels.Responses;
 using Microsoft.Extensions.Logging;
@@ -72,32 +71,50 @@ public class FreeTierUnsubscribedVpnDigestBotServiceTests
     }
 }
 
-public class FreeTierEmailRemindKeyboardTests
+public class FreeTierRemindKeyboardTests
 {
     [Fact]
-    public void BuildEmailRemindKeyboard_OnlyCandidatesWithEmail()
+    public void BuildRemindKeyboard_IncludesTgAndEmailButtons()
     {
-        var keyboard = DataGateVPNBot.Handlers.TelegramUpdateHandler.BuildEmailRemindKeyboard(
+        var keyboard = DataGateVPNBot.Handlers.TelegramUpdateHandler.BuildRemindKeyboard(
         [
-            new FreeTierEnforcementCandidateDto { UserId = 150, DisplayName = "A", Email = "a@x.com" },
-            new FreeTierEnforcementCandidateDto { UserId = 7, DisplayName = "B", Email = null },
-            new FreeTierEnforcementCandidateDto { UserId = 9, DisplayName = "C", Email = "  " },
-            new FreeTierEnforcementCandidateDto { UserId = 3, DisplayName = "D", Email = "d@x.com" },
+            new FreeTierEnforcementCandidateDto
+            {
+                UserId = 22,
+                DisplayName = "Irina",
+                Email = "irina@x.com",
+                TelegramId = 439938925,
+            },
+            new FreeTierEnforcementCandidateDto
+            {
+                UserId = 150,
+                DisplayName = "Tatyana",
+                Email = "t@x.com",
+                TelegramId = null,
+            },
+            new FreeTierEnforcementCandidateDto
+            {
+                UserId = 7,
+                DisplayName = "NoContact",
+                Email = null,
+                TelegramId = null,
+            },
         ]);
 
         Assert.NotNull(keyboard);
         var buttons = keyboard!.InlineKeyboard.SelectMany(r => r).ToList();
-        Assert.Equal(2, buttons.Count);
+        Assert.Contains(buttons, b => b.Text == "TG #22" && b.CallbackData == "/remind_channel_subscribe 22");
+        Assert.Contains(buttons, b => b.Text == "Email #22" && b.CallbackData == "/remind_channel_email 22");
         Assert.Contains(buttons, b => b.Text == "Email #150" && b.CallbackData == "/remind_channel_email 150");
-        Assert.Contains(buttons, b => b.Text == "Email #3" && b.CallbackData == "/remind_channel_email 3");
+        Assert.DoesNotContain(buttons, b => b.CallbackData!.Contains(" 7"));
     }
 
     [Fact]
-    public void BuildEmailRemindKeyboard_ReturnsNull_WhenNoEmails()
+    public void BuildRemindKeyboard_ReturnsNull_WhenNoContacts()
     {
-        var keyboard = DataGateVPNBot.Handlers.TelegramUpdateHandler.BuildEmailRemindKeyboard(
+        var keyboard = DataGateVPNBot.Handlers.TelegramUpdateHandler.BuildRemindKeyboard(
         [
-            new FreeTierEnforcementCandidateDto { UserId = 1, Email = null },
+            new FreeTierEnforcementCandidateDto { UserId = 1, Email = null, TelegramId = null },
         ]);
 
         Assert.Null(keyboard);

--- a/DataGateVPNBot.Tests/Services/HttpRequestServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/HttpRequestServiceTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using DataGateVPNBot.Services.Http;
 using DataGateVPNBot.Services.Interfaces;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -37,7 +38,7 @@ public class HttpRequestServiceTests
     [Fact]
     public async Task GetAsync_Throws_After_Retries_When_Response_Not_Success()
     {
-        var handler = new FakeHttpMessageHandler(HttpStatusCode.NotFound, "{}");
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.InternalServerError, "{}");
         var client = new HttpClient(handler);
         var factory = new Mock<IHttpClientFactoryService>();
         factory.Setup(f => f.CreateDashboardClient()).Returns(client);
@@ -49,6 +50,51 @@ public class HttpRequestServiceTests
 
         await Assert.ThrowsAsync<HttpRequestException>(() =>
             sut.GetAsync<TestDto>("https://api.example.com/foo", null, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PostAsync_Returns_Deserialized_ApiResponse_On_BadRequest_Without_Retry()
+    {
+        var json = """{"success":false,"message":"TelegramAlreadyLinkedToGoogle|koz_nik (a@b.c)","data":null}""";
+        var handler = new CountingHttpMessageHandler(HttpStatusCode.BadRequest, json);
+        var client = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactoryService>();
+        factory.Setup(f => f.CreateDashboardClient()).Returns(client);
+        var errorService = new Mock<IErrorService>();
+        var services = new ServiceCollection();
+        services.AddScoped(_ => errorService.Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var sut = new HttpRequestService(factory.Object, serviceProvider, Mock.Of<ILogger<HttpRequestService>>());
+        var result = await sut.PostAsync<ApiErrorDto>("https://api.example.com/link", new { }, null, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.False(result!.Success);
+        Assert.Equal("TelegramAlreadyLinkedToGoogle|koz_nik (a@b.c)", result.Message);
+        Assert.Equal(1, handler.SendCount);
+        errorService.Verify(
+            e => e.NotifyAdminsAboutExceptionAsync(It.IsAny<Exception>(), It.IsAny<HttpContext?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PostAsync_Returns_Deserialized_ApiResponse_On_Forbidden_Quota_Denial()
+    {
+        var json = """{"success":false,"message":"VpnServerNotAllowedByQuotaPlan","data":null}""";
+        var handler = new CountingHttpMessageHandler(HttpStatusCode.Forbidden, json);
+        var client = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactoryService>();
+        factory.Setup(f => f.CreateDashboardClient()).Returns(client);
+        var services = new ServiceCollection();
+        services.AddScoped<IErrorService>(_ => Mock.Of<IErrorService>());
+        var serviceProvider = services.BuildServiceProvider();
+
+        var sut = new HttpRequestService(factory.Object, serviceProvider, Mock.Of<ILogger<HttpRequestService>>());
+        var result = await sut.PostAsync<ApiErrorDto>("https://api.example.com/ovpn", new { }, null, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("VpnServerNotAllowedByQuotaPlan", result!.Message);
+        Assert.Equal(1, handler.SendCount);
     }
 
     [Fact]
@@ -95,6 +141,12 @@ public class HttpRequestServiceTests
         public string? Name { get; set; }
     }
 
+    private sealed class ApiErrorDto
+    {
+        public bool Success { get; set; }
+        public string? Message { get; set; }
+    }
+
     private sealed class FakeHttpMessageHandler : HttpMessageHandler
     {
         private readonly HttpStatusCode _statusCode;
@@ -115,6 +167,21 @@ public class HttpRequestServiceTests
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return Task.FromResult(new HttpResponseMessage(_statusCode)
+            {
+                Content = new ByteArrayContent(_content)
+            });
+        }
+    }
+
+    private sealed class CountingHttpMessageHandler(HttpStatusCode statusCode, string content) : HttpMessageHandler
+    {
+        private readonly byte[] _content = Encoding.UTF8.GetBytes(content);
+        public int SendCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            SendCount++;
+            return Task.FromResult(new HttpResponseMessage(statusCode)
             {
                 Content = new ByteArrayContent(_content)
             });

--- a/DataGateVPNBot.Tests/Services/TelegramBotUserServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/TelegramBotUserServiceTests.cs
@@ -1,10 +1,9 @@
+using DataGateVPNBot.Services.BotServices.Interfaces;
 using DataGateVPNBot.Services.DashboardServices;
 using DataGateVPNBot.Services.Http;
 using Microsoft.Extensions.Logging;
 using Moq;
-using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Responses;
 using DataGateMonitor.SharedModels.DataGateMonitor.User.Requests;
-using DataGateMonitor.SharedModels.DataGateMonitor.User.Responses;
 using DataGateMonitor.SharedModels.Responses;
 using DataGateVPNBot.Services.Interfaces;
 using Xunit;
@@ -13,13 +12,23 @@ namespace DataGateVPNBot.Tests.Services;
 
 public class TelegramBotUserServiceTests
 {
+    private static TelegramBotUserService CreateSut(
+        IHttpRequestService httpRequest,
+        AuthService authService,
+        IErrorService? errorService = null)
+        => new(
+            Mock.Of<ILogger<TelegramBotUserService>>(),
+            httpRequest,
+            authService,
+            errorService ?? Mock.Of<IErrorService>(),
+            Mock.Of<ITelegramProfilePhotoDownloader>());
+
     [Fact]
     public async Task RegisterUserAsync_Throws_When_TelegramId_Zero()
     {
         var httpRequest = new Mock<IHttpRequestService>();
         var authService = new AuthService(httpRequest.Object, "c", "s", Mock.Of<ILogger<AuthService>>());
-        var errorService = Mock.Of<IErrorService>();
-        var sut = new TelegramBotUserService(Mock.Of<ILogger<TelegramBotUserService>>(), httpRequest.Object, authService, errorService);
+        var sut = CreateSut(httpRequest.Object, authService);
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
             sut.RegisterUserAsync(new RegisterUserFromTgBotRequest { TelegramId = 0 }, CancellationToken.None));
@@ -32,8 +41,7 @@ public class TelegramBotUserServiceTests
         httpRequest.Setup(h => h.PostAsync<ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse>>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ApiResponse<DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses.TokenResponse> { Success = false });
         var authService = new AuthService(httpRequest.Object, "c", "s", Mock.Of<ILogger<AuthService>>());
-        var errorService = Mock.Of<IErrorService>();
-        var sut = new TelegramBotUserService(Mock.Of<ILogger<TelegramBotUserService>>(), httpRequest.Object, authService, errorService);
+        var sut = CreateSut(httpRequest.Object, authService);
 
         await Assert.ThrowsAsync<System.Security.Authentication.AuthenticationException>(() =>
             sut.GetAdminsAsync(CancellationToken.None));
@@ -55,7 +63,7 @@ public class TelegramBotUserServiceTests
             .ReturnsAsync(new ApiResponse<bool> { Success = true, Data = false, Message = "Success" });
 
         var authService = new AuthService(httpRequest.Object, "c", "s", Mock.Of<ILogger<AuthService>>());
-        var sut = new TelegramBotUserService(Mock.Of<ILogger<TelegramBotUserService>>(), httpRequest.Object, authService, Mock.Of<IErrorService>());
+        var sut = CreateSut(httpRequest.Object, authService);
 
         var exists = await sut.UserExistsAsync(372608421, CancellationToken.None);
 

--- a/DataGateVPNBot.Tests/Services/TelegramSettingsServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/TelegramSettingsServiceTests.cs
@@ -34,6 +34,24 @@ public class TelegramSettingsServiceTests
         Assert.Contains("/get_my_files", commandStrings);
         Assert.Contains("/make_new_file", commandStrings);
         Assert.Contains("/how_to_use", commandStrings);
+        Assert.DoesNotContain("/unsubscribed_vpn_users", commandStrings);
+        Assert.DoesNotContain("/refresh_profile_photos", commandStrings);
+        Assert.DoesNotContain("/remind_channel_subscribe", commandStrings);
+        Assert.DoesNotContain("/remind_channel_email", commandStrings);
+    }
+
+    [Fact]
+    public void GetTelegramMenuByLanguage_WithAdminCommands_IncludesAdminOnlyEntries()
+    {
+        var sut = new TelegramSettingsService();
+        var commands = sut.GetTelegramMenuByLanguage(Language.English, includeAdminCommands: true);
+
+        var commandStrings = commands.Select(c => c.Command).ToArray();
+        Assert.Contains("/unsubscribed_vpn_users", commandStrings);
+        Assert.Contains("/refresh_profile_photos", commandStrings);
+        Assert.Contains("/remind_channel_subscribe", commandStrings);
+        Assert.Contains("/remind_channel_email", commandStrings);
+        Assert.Contains("/get_my_files", commandStrings);
     }
 
     [Fact]

--- a/DataGateVPNBot.Tests/Services/XrayClientLinksDashboardServiceTests.cs
+++ b/DataGateVPNBot.Tests/Services/XrayClientLinksDashboardServiceTests.cs
@@ -1,0 +1,97 @@
+using DataGateVPNBot.Localization;
+using DataGateVPNBot.Services.DashboardServices;
+using DataGateVPNBot.Services.Http;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Responses;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace DataGateVPNBot.Tests.Services;
+
+public class XrayClientLinksDashboardServiceTests
+{
+    [Fact]
+    public async Task AddOvpnFileWithTokenAsync_Throws_With_Api_Message_On_Quota_Denial()
+    {
+        var httpRequest = new Mock<IHttpRequestService>();
+        httpRequest.Setup(h => h.PostAsync<ApiResponse<TokenResponse>>(
+                It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<TokenResponse>
+            {
+                Success = true,
+                Data = new TokenResponse { Token = "jwt", Expiration = DateTimeOffset.UtcNow.AddHours(1) },
+            });
+        httpRequest.Setup(h => h.PostAsync<ApiResponse<OvpnFileWithTokenResponse>>(
+                "api/xray-client-links/add-with-token",
+                It.IsAny<object>(),
+                "jwt",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<OvpnFileWithTokenResponse>
+            {
+                Success = false,
+                Message = ApiErrorMessageMapper.VpnServerNotAllowedByQuotaPlanKey,
+                Data = null,
+            });
+
+        var auth = new AuthService(httpRequest.Object, "clientId", "secret", Mock.Of<ILogger<AuthService>>());
+        var sut = new XrayClientLinksDashboardService(
+            Mock.Of<ILogger<XrayClientLinksDashboardService>>(),
+            httpRequest.Object,
+            auth);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.AddOvpnFileWithTokenAsync(new AddFileRequest
+            {
+                VpnServerId = 77,
+                ExternalId = "123",
+                CommonName = "cn",
+            }, CancellationToken.None));
+
+        Assert.Equal(ApiErrorMessageMapper.VpnServerNotAllowedByQuotaPlanKey, ex.Message);
+        Assert.True(ApiErrorMessageMapper.TryMap(ex.Message, out var mapped));
+        Assert.Equal(ApiErrorMessageMapper.LocalizationVpnServerNotAllowedByQuotaPlan, mapped.LocalizationKey);
+    }
+
+    [Fact]
+    public async Task AddOvpnFileAsync_Throws_With_Api_Message_On_Quota_Denial()
+    {
+        var httpRequest = new Mock<IHttpRequestService>();
+        httpRequest.Setup(h => h.PostAsync<ApiResponse<TokenResponse>>(
+                It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<TokenResponse>
+            {
+                Success = true,
+                Data = new TokenResponse { Token = "jwt", Expiration = DateTimeOffset.UtcNow.AddHours(1) },
+            });
+        httpRequest.Setup(h => h.PostAsync<ApiResponse<OvpnFileResponse>>(
+                "api/xray-client-links/add",
+                It.IsAny<object>(),
+                "jwt",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApiResponse<OvpnFileResponse>
+            {
+                Success = false,
+                Message = ApiErrorMessageMapper.VpnServerNotAllowedByQuotaPlanKey,
+                Data = null,
+            });
+
+        var auth = new AuthService(httpRequest.Object, "clientId", "secret", Mock.Of<ILogger<AuthService>>());
+        var sut = new XrayClientLinksDashboardService(
+            Mock.Of<ILogger<XrayClientLinksDashboardService>>(),
+            httpRequest.Object,
+            auth);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.AddOvpnFileAsync(new AddFileRequest
+            {
+                VpnServerId = 77,
+                ExternalId = "123",
+                CommonName = "cn",
+            }, CancellationToken.None));
+
+        Assert.Equal(ApiErrorMessageMapper.VpnServerNotAllowedByQuotaPlanKey, ex.Message);
+    }
+}

--- a/DataGateVPNBot/Configurations/ServiceConfiguration.cs
+++ b/DataGateVPNBot/Configurations/ServiceConfiguration.cs
@@ -35,6 +35,7 @@ public static class ServiceConfiguration
         services.AddScoped<IOvpnFileService, OvpnFileService>();
         services.AddScoped<IFreeTierAccessComplianceBotService, FreeTierAccessComplianceBotService>();
         services.AddScoped<IFreeTierUnsubscribedVpnDigestBotService, FreeTierUnsubscribedVpnDigestBotService>();
+        services.AddScoped<IFreeTierChannelSubscribeRemindBotService, FreeTierChannelSubscribeRemindBotService>();
         services.AddScoped<IXrayClientLinkBotService, XrayClientLinkBotService>();
         services.AddScoped<IVpnProfileTokenDownloadService, VpnProfileTokenDownloadService>();
         services.AddSingleton<ServerService>();

--- a/DataGateVPNBot/Configurations/ServiceConfiguration.cs
+++ b/DataGateVPNBot/Configurations/ServiceConfiguration.cs
@@ -23,6 +23,7 @@ public static class ServiceConfiguration
         
         services.AddScoped<IIncomingMessageLogService, IncomingMessageLogService>();
         services.AddScoped<ITelegramBotUserService, TelegramBotUserService>();
+        services.AddScoped<ITelegramProfilePhotoDownloader, TelegramProfilePhotoDownloader>();
         services.AddScoped<ITelegramUserProfilePhotoRefreshService, TelegramUserProfilePhotoRefreshService>();
         services.AddHostedService<MonthlyProfilePhotoRefreshHostedService>();
         services.AddScoped<ILocalizationService, LocalizationService>();
@@ -33,6 +34,7 @@ public static class ServiceConfiguration
         services.AddScoped<IOpenVpnServersService, OpenVpnServersService>();
         services.AddScoped<IOvpnFileService, OvpnFileService>();
         services.AddScoped<IFreeTierAccessComplianceBotService, FreeTierAccessComplianceBotService>();
+        services.AddScoped<IFreeTierUnsubscribedVpnDigestBotService, FreeTierUnsubscribedVpnDigestBotService>();
         services.AddScoped<IXrayClientLinkBotService, XrayClientLinkBotService>();
         services.AddScoped<IVpnProfileTokenDownloadService, VpnProfileTokenDownloadService>();
         services.AddSingleton<ServerService>();

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -6,9 +6,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <ApplicationIcon>logo/logo.ico</ApplicationIcon>
-        <Version>1.2.3.20</Version>
-        <AssemblyVersion>1.2.3.20</AssemblyVersion>
-        <FileVersion>1.2.3.20</FileVersion>
+        <Version>1.2.3.23</Version>
+        <AssemblyVersion>1.2.3.23</AssemblyVersion>
+        <FileVersion>1.2.3.23</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -23,7 +23,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
         <!-- SharedModels: NuGet only (never ProjectReference). Bump after publishing a new package version. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.50" />
         <PackageReference Include="Serilog" Version="4.4.0" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -6,9 +6,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <ApplicationIcon>logo/logo.ico</ApplicationIcon>
-        <Version>1.2.3.23</Version>
-        <AssemblyVersion>1.2.3.23</AssemblyVersion>
-        <FileVersion>1.2.3.23</FileVersion>
+        <Version>1.2.3.24</Version>
+        <AssemblyVersion>1.2.3.24</AssemblyVersion>
+        <FileVersion>1.2.3.24</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -6,32 +6,32 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <ApplicationIcon>logo/logo.ico</ApplicationIcon>
-        <Version>1.2.3.15</Version>
-        <AssemblyVersion>1.2.3.15</AssemblyVersion>
-        <FileVersion>1.2.3.15</FileVersion>
+        <Version>1.2.3.16</Version>
+        <AssemblyVersion>1.2.3.16</AssemblyVersion>
+        <FileVersion>1.2.3.16</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="ACMESharpCore" Version="2.2.0.148" />
         <PackageReference Include="Certes" Version="3.0.4" />
-        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.4.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.5.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.10" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
         <!-- SharedModels: NuGet only (never ProjectReference). Bump after publishing a new package version. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.35" />
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
         <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />
-        <PackageReference Include="Telegram.Bot" Version="22.10.1" />
+        <PackageReference Include="Telegram.Bot" Version="22.10.2.1" />
         <PackageReference Include="Telegram.Bot.AspNetCore" Version="22.5.0" />
     </ItemGroup>
 

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -6,8 +6,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <ApplicationIcon>logo/logo.ico</ApplicationIcon>
-        <AssemblyVersion>1.2.3.14</AssemblyVersion>
-        <FileVersion>1.2.3.14</FileVersion>
+        <Version>1.2.3.15</Version>
+        <AssemblyVersion>1.2.3.15</AssemblyVersion>
+        <FileVersion>1.2.3.15</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DataGateVPNBot/DataGateVPNBot.csproj
+++ b/DataGateVPNBot/DataGateVPNBot.csproj
@@ -6,9 +6,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <ApplicationIcon>logo/logo.ico</ApplicationIcon>
-        <Version>1.2.3.16</Version>
-        <AssemblyVersion>1.2.3.16</AssemblyVersion>
-        <FileVersion>1.2.3.16</FileVersion>
+        <Version>1.2.3.20</Version>
+        <AssemblyVersion>1.2.3.20</AssemblyVersion>
+        <FileVersion>1.2.3.20</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DataGateVPNBot/Handlers/BotCommands.cs
+++ b/DataGateVPNBot/Handlers/BotCommands.cs
@@ -39,4 +39,7 @@ public static class BotCommands
 
     /// <summary>Admin only: push current Telegram profile photos into the dashboard for every registered user.</summary>
     public const string CommandRefreshProfilePhotos = "/refresh_profile_photos";
+
+    /// <summary>Admin only: force the Free/Default unsubscribed-online VPN digest (same as daily admin alert).</summary>
+    public const string CommandUnsubscribedVpnUsers = "/unsubscribed_vpn_users";
 }

--- a/DataGateVPNBot/Handlers/BotCommands.cs
+++ b/DataGateVPNBot/Handlers/BotCommands.cs
@@ -42,4 +42,10 @@ public static class BotCommands
 
     /// <summary>Admin only: force the Free/Default unsubscribed-online VPN digest (same as daily admin alert).</summary>
     public const string CommandUnsubscribedVpnUsers = "/unsubscribed_vpn_users";
+
+    /// <summary>Admin only: send a localized channel-subscribe reminder to a user (userId or Telegram id).</summary>
+    public const string CommandRemindChannelSubscribe = "/remind_channel_subscribe";
+
+    /// <summary>Admin only: email a channel-subscribe reminder to a dashboard userId.</summary>
+    public const string CommandRemindChannelEmail = "/remind_channel_email";
 }

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.AccountLink.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.AccountLink.cs
@@ -1,4 +1,5 @@
 using DataGateVPNBot.Helpers;
+using DataGateVPNBot.Localization;
 using Telegram.Bot;
 using Telegram.Bot.Types;
 
@@ -6,8 +7,6 @@ namespace DataGateVPNBot.Handlers;
 
 public partial class TelegramUpdateHandler
 {
-    private const string TelegramAlreadyLinkedToGooglePrefix = "TelegramAlreadyLinkedToGoogle|";
-
     private async Task<Message> CompleteAccountLinkFromBotAsync(
         Message msg,
         string code,
@@ -35,13 +34,12 @@ public partial class TelegramUpdateHandler
         {
             text = "✅ " + await GetLocalizationTextAsync("AccountLinkAlreadyLinked", telegramId, cancellationToken);
         }
-        else if (result?.Message?.StartsWith(TelegramAlreadyLinkedToGooglePrefix, StringComparison.Ordinal) == true)
+        else if (ApiErrorMessageMapper.TryMap(result?.Message, out var mapped))
         {
-            var label = result.Message[TelegramAlreadyLinkedToGooglePrefix.Length..];
             text = "❌ " + await GetLocalizationTextAsync(
-                "AccountLinkTelegramAlreadyLinkedToGoogle",
+                mapped.LocalizationKey,
                 telegramId,
-                new Dictionary<string, string> { ["accountLabel"] = label },
+                mapped.Placeholders ?? new Dictionary<string, string>(),
                 cancellationToken);
         }
         else if (result?.Message?.Contains("not registered", StringComparison.OrdinalIgnoreCase) == true)

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.Files.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.Files.cs
@@ -1,4 +1,5 @@
 ﻿using DataGateVPNBot.Helpers;
+using DataGateVPNBot.Localization;
 using DataGateVPNBot.Services.BotServices.Interfaces;
 using DataGateVPNBot.Services.DashboardServices;
 using DataGateVPNBot.Services.Interfaces;
@@ -302,17 +303,9 @@ public partial class TelegramUpdateHandler
             return messages.FirstOrDefault() ??
                    throw new InvalidOperationException("No messages returned after sending media group.");
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            using var scope = serviceProvider.CreateScope();
-            var errorService = scope.ServiceProvider.GetRequiredService<IErrorService>();
-            await errorService.NotifyAdminsAboutExceptionAsync(ex, null, cancellationToken);
-            return await _botClient.SendMessage(
-                msg.Chat,
-                await GetLocalizationTextAsync("SomethingWentWrongWhenTryMakeNewFile", 
-                    msg.Chat.Id, cancellationToken) + " Details: " + ex.Message,
-                replyMarkup: new ReplyKeyboardRemove(),
-                cancellationToken: cancellationToken);
+            return await SendMakeNewFileErrorAsync(msg, ex, cancellationToken);
         }
     }
     
@@ -408,18 +401,50 @@ public partial class TelegramUpdateHandler
             return messages.FirstOrDefault() ??
                    throw new InvalidOperationException("No messages returned after sending media group.");
         }
-        catch(Exception ex)
+        catch (Exception ex)
+        {
+            return await SendMakeNewFileErrorAsync(msg, ex, cancellationToken);
+        }
+    }
+
+    private async Task<Message> SendMakeNewFileErrorAsync(
+        Message msg,
+        Exception ex,
+        CancellationToken cancellationToken)
+    {
+        var telegramId = msg.Chat.Id;
+        string text;
+        var isExpectedBusinessError = false;
+
+        if (ApiErrorMessageMapper.TryMap(ex.Message, out var mapped))
+        {
+            isExpectedBusinessError = mapped.IsExpectedBusinessError;
+            text = await GetLocalizationTextAsync(
+                mapped.LocalizationKey,
+                telegramId,
+                mapped.Placeholders ?? new Dictionary<string, string>(),
+                cancellationToken);
+        }
+        else
+        {
+            text = await GetLocalizationTextAsync(
+                "SomethingWentWrongWhenTryMakeNewFile",
+                telegramId,
+                cancellationToken);
+        }
+
+        if (!isExpectedBusinessError)
         {
             using var scope = serviceProvider.CreateScope();
             var errorService = scope.ServiceProvider.GetRequiredService<IErrorService>();
             await errorService.NotifyAdminsAboutExceptionAsync(ex, null, cancellationToken);
-            return await _botClient.SendMessage(
-                msg.Chat,
-                await GetLocalizationTextAsync("SomethingWentWrongWhenTryMakeNewFile", 
-                    msg.Chat.Id, cancellationToken) + " Details: " + ex.Message,
-                replyMarkup: new ReplyKeyboardRemove(),
-                cancellationToken: cancellationToken);
         }
+
+        return await _botClient.SendMessage(
+            msg.Chat,
+            text,
+            replyMarkup: new ReplyKeyboardRemove(),
+            cancellationToken: cancellationToken);
     }
     
     private async Task<Message> DeleteAllFiles(Message msg, string? vpnServerIdArg, CancellationToken cancellationToken)

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.InformationalUpdates.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.InformationalUpdates.cs
@@ -1,0 +1,288 @@
+using DataGateVPNBot.Services.Interfaces;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Payments;
+
+namespace DataGateVPNBot.Handlers;
+
+public partial class TelegramUpdateHandler
+{
+    private async Task OnChatBoostUpdateAsync(ChatBoostUpdated update, CancellationToken cancellationToken)
+    {
+        var boost = update.Boost;
+        var (who, source) = DescribeBoostSource(boost?.Source);
+
+        var text =
+            "ℹ️ Chat boost added\n" +
+            $"Chat: {DescribeChat(update.Chat)}\n" +
+            $"User: {who}\n" +
+            $"Source: {source}\n" +
+            $"BoostId: {boost?.BoostId ?? "Unknown"}\n" +
+            $"Added: {FormatUtc(boost?.AddDate)}\n" +
+            $"Expires: {FormatUtc(boost?.ExpirationDate)}";
+
+        _logger.LogInformation(
+            "ChatBoost update. Chat={Chat}; Who={Who}; BoostId={BoostId}",
+            DescribeChat(update.Chat), who, boost?.BoostId);
+
+        await NotifyAdminsInformationalAsync(text, cancellationToken);
+    }
+
+    private async Task OnRemovedChatBoostUpdateAsync(ChatBoostRemoved update, CancellationToken cancellationToken)
+    {
+        var (who, source) = DescribeBoostSource(update.Source);
+
+        var text =
+            "ℹ️ Chat boost removed\n" +
+            $"Chat: {DescribeChat(update.Chat)}\n" +
+            $"User: {who}\n" +
+            $"Source: {source}\n" +
+            $"BoostId: {update.BoostId}\n" +
+            $"Removed: {FormatUtc(update.RemoveDate)}";
+
+        _logger.LogInformation(
+            "RemovedChatBoost update. Chat={Chat}; Who={Who}; BoostId={BoostId}",
+            DescribeChat(update.Chat), who, update.BoostId);
+
+        await NotifyAdminsInformationalAsync(text, cancellationToken);
+    }
+
+    private async Task OnChatJoinRequestUpdateAsync(ChatJoinRequest update, CancellationToken cancellationToken)
+    {
+        var invite = update.InviteLink?.InviteLink
+                     ?? (string.IsNullOrWhiteSpace(update.InviteLink?.Name) ? "—" : update.InviteLink.Name);
+
+        var text =
+            "ℹ️ Join request\n" +
+            $"Chat: {DescribeChat(update.Chat)}\n" +
+            $"User: {DescribeUser(update.From)}\n" +
+            $"Invite: {invite}\n" +
+            $"Bio: {Truncate(update.Bio, 200)}\n" +
+            $"Time: {FormatUtc(update.Date)}";
+
+        _logger.LogInformation(
+            "ChatJoinRequest update. Chat={Chat}; Who={Who}",
+            DescribeChat(update.Chat), DescribeUser(update.From));
+
+        await NotifyAdminsInformationalAsync(text, cancellationToken);
+    }
+
+    private async Task OnMessageReactionUpdateAsync(MessageReactionUpdated update, CancellationToken cancellationToken)
+    {
+        var actor = update.User != null
+            ? DescribeUser(update.User)
+            : update.ActorChat != null
+                ? DescribeChat(update.ActorChat)
+                : "Unknown";
+
+        var text =
+            "ℹ️ Message reaction\n" +
+            $"Chat: {DescribeChat(update.Chat)}\n" +
+            $"User: {actor}\n" +
+            $"MessageId: {update.MessageId}\n" +
+            $"{DescribeReactions(update.OldReaction)} -> {DescribeReactions(update.NewReaction)}\n" +
+            $"Time: {FormatUtc(update.Date)}";
+
+        _logger.LogInformation(
+            "MessageReaction update. Chat={Chat}; MessageId={MessageId}; Who={Who}",
+            DescribeChat(update.Chat), update.MessageId, actor);
+
+        await NotifyAdminsInformationalAsync(text, cancellationToken);
+    }
+
+    private async Task OnMessageReactionCountUpdateAsync(MessageReactionCountUpdated update, CancellationToken cancellationToken)
+    {
+        var counts = update.Reactions is { Length: > 0 }
+            ? string.Join(", ", update.Reactions.Select(r => $"{DescribeReaction(r.Type)}×{r.TotalCount}"))
+            : "none";
+
+        var text =
+            "ℹ️ Message reaction counts\n" +
+            $"Chat: {DescribeChat(update.Chat)}\n" +
+            $"MessageId: {update.MessageId}\n" +
+            $"Counts: {counts}\n" +
+            $"Time: {FormatUtc(update.Date)}";
+
+        _logger.LogInformation(
+            "MessageReactionCount update. Chat={Chat}; MessageId={MessageId}",
+            DescribeChat(update.Chat), update.MessageId);
+
+        await NotifyAdminsInformationalAsync(text, cancellationToken);
+    }
+
+    private async Task OnBusinessConnectionUpdateAsync(BusinessConnection update, CancellationToken cancellationToken)
+    {
+        var text =
+            "ℹ️ Business connection\n" +
+            $"User: {DescribeUser(update.User)}\n" +
+            $"Enabled: {update.IsEnabled}\n" +
+            $"ConnectionId: {update.Id}\n" +
+            $"UserChatId: {update.UserChatId}\n" +
+            $"Time: {FormatUtc(update.Date)}";
+
+        _logger.LogInformation(
+            "BusinessConnection update. Id={Id}; User={User}; IsEnabled={IsEnabled}",
+            update.Id, DescribeUser(update.User), update.IsEnabled);
+
+        await NotifyAdminsInformationalAsync(text, cancellationToken);
+    }
+
+    private async Task OnDeletedBusinessMessagesUpdateAsync(BusinessMessagesDeleted update, CancellationToken cancellationToken)
+    {
+        var ids = update.MessageIds is { Length: > 0 }
+            ? string.Join(", ", update.MessageIds.Take(20)) + (update.MessageIds.Length > 20 ? "…" : "")
+            : "none";
+
+        var text =
+            "ℹ️ Business messages deleted\n" +
+            $"Chat: {DescribeChat(update.Chat)}\n" +
+            $"ConnectionId: {update.BusinessConnectionId}\n" +
+            $"Count: {update.MessageIds?.Length ?? 0}\n" +
+            $"MessageIds: {ids}";
+
+        _logger.LogInformation(
+            "DeletedBusinessMessages update. ConnectionId={Id}; Chat={Chat}; Count={Count}",
+            update.BusinessConnectionId, DescribeChat(update.Chat), update.MessageIds?.Length ?? 0);
+
+        await NotifyAdminsInformationalAsync(text, cancellationToken);
+    }
+
+    private async Task OnShippingQueryUpdateAsync(ShippingQuery update, CancellationToken cancellationToken)
+    {
+        var address = update.ShippingAddress;
+        var addressText = address == null
+            ? "—"
+            : string.Join(", ", new[]
+            {
+                address.CountryCode,
+                address.State,
+                address.City,
+                address.StreetLine1,
+                address.StreetLine2,
+                address.PostCode
+            }.Where(s => !string.IsNullOrWhiteSpace(s)));
+
+        var text =
+            "ℹ️ Shipping query\n" +
+            $"User: {DescribeUser(update.From)}\n" +
+            $"QueryId: {update.Id}\n" +
+            $"Payload: {Truncate(update.InvoicePayload, 200)}\n" +
+            $"Address: {addressText}";
+
+        _logger.LogInformation("ShippingQuery update. QueryId={Id}; Who={Who}", update.Id, DescribeUser(update.From));
+
+        await NotifyAdminsInformationalAsync(text, cancellationToken);
+    }
+
+    private async Task OnPreCheckoutQueryUpdateAsync(PreCheckoutQuery update, CancellationToken cancellationToken)
+    {
+        var text =
+            "ℹ️ Pre-checkout query\n" +
+            $"User: {DescribeUser(update.From)}\n" +
+            $"QueryId: {update.Id}\n" +
+            $"Amount: {update.TotalAmount} {update.Currency}\n" +
+            $"Payload: {Truncate(update.InvoicePayload, 200)}\n" +
+            $"ShippingOptionId: {update.ShippingOptionId ?? "—"}";
+
+        _logger.LogInformation(
+            "PreCheckoutQuery update. QueryId={Id}; Who={Who}; Amount={Amount} {Currency}",
+            update.Id, DescribeUser(update.From), update.TotalAmount, update.Currency);
+
+        await NotifyAdminsInformationalAsync(text, cancellationToken);
+    }
+
+    private async Task OnPurchasedPaidMediaUpdateAsync(PaidMediaPurchased update, CancellationToken cancellationToken)
+    {
+        var text =
+            "ℹ️ Paid media purchased\n" +
+            $"User: {DescribeUser(update.From)}\n" +
+            $"Payload: {Truncate(update.PaidMediaPayload, 200)}";
+
+        _logger.LogInformation(
+            "PurchasedPaidMedia update. Who={Who}; Payload={Payload}",
+            DescribeUser(update.From), update.PaidMediaPayload);
+
+        await NotifyAdminsInformationalAsync(text, cancellationToken);
+    }
+
+    private async Task OnManagedBotUpdateAsync(ManagedBotUpdated update, CancellationToken cancellationToken)
+    {
+        var text =
+            "ℹ️ Managed bot update\n" +
+            $"Owner: {DescribeUser(update.User)}\n" +
+            $"Bot: {DescribeUser(update.Bot)}";
+
+        _logger.LogInformation(
+            "ManagedBot update. User={User}; Bot={Bot}",
+            DescribeUser(update.User), DescribeUser(update.Bot));
+
+        await NotifyAdminsInformationalAsync(text, cancellationToken);
+    }
+
+    private async Task OnSubscriptionUpdateAsync(BotSubscriptionUpdated update, CancellationToken cancellationToken)
+    {
+        var text =
+            "ℹ️ Payment subscription\n" +
+            $"User: {DescribeUser(update.User)}\n" +
+            $"State: {update.State}\n" +
+            $"Payload: {Truncate(update.InvoicePayload, 200)}";
+
+        _logger.LogInformation(
+            "Subscription update. Who={Who}; State={State}",
+            DescribeUser(update.User), update.State);
+
+        await NotifyAdminsInformationalAsync(text, cancellationToken);
+    }
+
+    private async Task NotifyAdminsInformationalAsync(string text, CancellationToken cancellationToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var errorService = scope.ServiceProvider.GetRequiredService<IErrorService>();
+        await errorService.SendMessageToAdminsAsync(text, cancellationToken);
+    }
+
+    private static (string Who, string Source) DescribeBoostSource(ChatBoostSource? source) =>
+        source switch
+        {
+            ChatBoostSourcePremium premium => (DescribeUser(premium.User), "Premium"),
+            ChatBoostSourceGiftCode giftCode => (DescribeUser(giftCode.User), "GiftCode"),
+            ChatBoostSourceGiveaway giveaway => (
+                giveaway.User != null
+                    ? DescribeUser(giveaway.User)
+                    : giveaway.IsUnclaimed ? "unclaimed" : "—",
+                $"Giveaway (msg={giveaway.GiveawayMessageId}" +
+                (giveaway.PrizeStarCount is { } stars ? $", stars={stars}" : "") + ")"),
+            null => ("Unknown", "—"),
+            _ => ("Unknown", source.Source.ToString())
+        };
+
+    private static string DescribeReactions(ReactionType[]? reactions)
+    {
+        if (reactions is not { Length: > 0 })
+            return "none";
+        return string.Join(", ", reactions.Select(DescribeReaction));
+    }
+
+    private static string DescribeReaction(ReactionType? reaction) =>
+        reaction switch
+        {
+            ReactionTypeEmoji emoji => emoji.Emoji,
+            ReactionTypeCustomEmoji custom => $"custom:{custom.CustomEmojiId}",
+            ReactionTypePaid => "paid",
+            null => "none",
+            _ => reaction.Type.ToString()
+        };
+
+    private static string FormatUtc(DateTime? dateTime)
+    {
+        if (dateTime is null || dateTime == default)
+            return $"{DateTimeOffset.UtcNow:yyyy-MM-dd HH:mm:ss} UTC";
+        return $"{dateTime.Value:yyyy-MM-dd HH:mm:ss} UTC";
+    }
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return "—";
+        return value.Length <= maxLength ? value : value[..maxLength] + "…";
+    }
+}

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.RemindChannelSubscribe.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.RemindChannelSubscribe.cs
@@ -43,6 +43,18 @@ public partial class TelegramUpdateHandler
             FreeTierChannelSubscribeRemindChannel.Email,
             cancellationToken);
 
+    private async Task<Message> AdminRemindChannelSubscribeFromCallbackAsync(
+        Message chatMessage,
+        User admin,
+        string? argument,
+        CancellationToken cancellationToken)
+        => await AdminRemindChannelAsync(
+            chatMessage,
+            admin,
+            argument,
+            FreeTierChannelSubscribeRemindChannel.Telegram,
+            cancellationToken);
+
     private async Task<Message> AdminRemindChannelAsync(
         Message msg,
         User? admin,

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.RemindChannelSubscribe.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.RemindChannelSubscribe.cs
@@ -1,0 +1,104 @@
+using System.Security.Authentication;
+using DataGateVPNBot.Services.BotServices.Interfaces;
+using DataGateVPNBot.Services.DashboardServices.Interfaces;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Enums;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+
+namespace DataGateVPNBot.Handlers;
+
+public partial class TelegramUpdateHandler
+{
+    private async Task<Message> AdminRemindChannelSubscribeAsync(
+        Message msg,
+        string? argument,
+        CancellationToken cancellationToken)
+        => await AdminRemindChannelAsync(
+            msg,
+            msg.From,
+            argument,
+            FreeTierChannelSubscribeRemindChannel.Telegram,
+            cancellationToken);
+
+    private async Task<Message> AdminRemindChannelEmailAsync(
+        Message msg,
+        string? argument,
+        CancellationToken cancellationToken)
+        => await AdminRemindChannelAsync(
+            msg,
+            msg.From,
+            argument,
+            FreeTierChannelSubscribeRemindChannel.Email,
+            cancellationToken);
+
+    private async Task<Message> AdminRemindChannelEmailFromCallbackAsync(
+        Message chatMessage,
+        User admin,
+        string? argument,
+        CancellationToken cancellationToken)
+        => await AdminRemindChannelAsync(
+            chatMessage,
+            admin,
+            argument,
+            FreeTierChannelSubscribeRemindChannel.Email,
+            cancellationToken);
+
+    private async Task<Message> AdminRemindChannelAsync(
+        Message msg,
+        User? admin,
+        string? argument,
+        FreeTierChannelSubscribeRemindChannel channel,
+        CancellationToken cancellationToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var tgUserService = scope.ServiceProvider.GetRequiredService<ITelegramBotUserService>();
+
+        var adminId = admin?.Id ?? 0;
+        if (adminId <= 0 ||
+            !await tgUserService.IsTelegramDashboardAdminAsync(adminId, cancellationToken))
+        {
+            return await _botClient.SendMessage(
+                msg.Chat.Id,
+                "⛔ This command is only for bot administrators.",
+                cancellationToken: cancellationToken);
+        }
+
+        if (string.IsNullOrWhiteSpace(argument))
+        {
+            var usage = channel == FreeTierChannelSubscribeRemindChannel.Email
+                ? "Usage: /remind_channel_email <userId>\nExample: /remind_channel_email 150"
+                : "Usage: /remind_channel_subscribe <userId|telegramId>\nExample: /remind_channel_subscribe 22";
+            return await _botClient.SendMessage(
+                msg.Chat.Id,
+                usage,
+                cancellationToken: cancellationToken);
+        }
+
+        try
+        {
+            var remindService = scope.ServiceProvider.GetRequiredService<IFreeTierChannelSubscribeRemindBotService>();
+            var result = await remindService.RemindAsync(argument, channel, cancellationToken);
+            var prefix = result.Success ? "" : "❌ ";
+            return await _botClient.SendMessage(
+                msg.Chat.Id,
+                prefix + result.Message,
+                cancellationToken: cancellationToken);
+        }
+        catch (AuthenticationException ex)
+        {
+            _logger.LogWarning(ex, "Admin channel-subscribe remind: authentication failed");
+            return await _botClient.SendMessage(
+                msg.Chat.Id,
+                "❌ Dashboard authentication failed. Try again later.",
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Admin channel-subscribe remind failed channel={Channel}", channel);
+            return await _botClient.SendMessage(
+                msg.Chat.Id,
+                "❌ Failed to send reminder. Check backend logs.",
+                cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.UnsubscribedVpnDigest.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.UnsubscribedVpnDigest.cs
@@ -1,8 +1,10 @@
 using System.Security.Authentication;
 using DataGateVPNBot.Services.BotServices.Interfaces;
 using DataGateVPNBot.Services.DashboardServices.Interfaces;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Dto;
 using Telegram.Bot;
 using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
 
 namespace DataGateVPNBot.Handlers;
 
@@ -31,9 +33,9 @@ public partial class TelegramUpdateHandler
         try
         {
             var digestService = scope.ServiceProvider.GetRequiredService<IFreeTierUnsubscribedVpnDigestBotService>();
-            var text = await digestService.GetDigestTextAsync(cancellationToken);
+            var digest = await digestService.GetDigestAsync(cancellationToken);
 
-            if (string.IsNullOrWhiteSpace(text))
+            if (digest is null || string.IsNullOrWhiteSpace(digest.Text))
             {
                 return await _botClient.SendMessage(
                     msg.Chat.Id,
@@ -41,12 +43,19 @@ public partial class TelegramUpdateHandler
                     cancellationToken: cancellationToken);
             }
 
-            if (text.Length > 4090)
-                text = text[..4090] + "…";
+            var liveText = digest.Text.StartsWith("📋", StringComparison.Ordinal) ||
+                           digest.Text.StartsWith("📅", StringComparison.Ordinal)
+                ? "🔎 Live snapshot\n" + digest.Text
+                : "🔎 Live snapshot\n\n" + digest.Text;
 
+            if (liveText.Length > 4090)
+                liveText = liveText[..4090] + "…";
+
+            var keyboard = BuildEmailRemindKeyboard(digest.Candidates);
             return await _botClient.SendMessage(
                 msg.Chat.Id,
-                text,
+                liveText,
+                replyMarkup: keyboard,
                 cancellationToken: cancellationToken);
         }
         catch (AuthenticationException ex)
@@ -65,5 +74,34 @@ public partial class TelegramUpdateHandler
                 "❌ Failed to load the digest. Check backend logs.",
                 cancellationToken: cancellationToken);
         }
+    }
+
+    public static InlineKeyboardMarkup? BuildEmailRemindKeyboard(
+        IReadOnlyList<FreeTierEnforcementCandidateDto>? candidates)
+    {
+        if (candidates is null || candidates.Count == 0)
+            return null;
+
+        var withEmail = candidates
+            .Where(c => !string.IsNullOrWhiteSpace(c.Email))
+            .OrderBy(c => c.DisplayName)
+            .Take(24)
+            .ToList();
+        if (withEmail.Count == 0)
+            return null;
+
+        var rows = new List<InlineKeyboardButton[]>();
+        const int perRow = 2;
+        for (var i = 0; i < withEmail.Count; i += perRow)
+        {
+            var chunk = withEmail.Skip(i).Take(perRow)
+                .Select(c => InlineKeyboardButton.WithCallbackData(
+                    $"Email #{c.UserId}",
+                    $"{BotCommands.CommandRemindChannelEmail} {c.UserId}"))
+                .ToArray();
+            rows.Add(chunk);
+        }
+
+        return new InlineKeyboardMarkup(rows);
     }
 }

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.UnsubscribedVpnDigest.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.UnsubscribedVpnDigest.cs
@@ -1,0 +1,69 @@
+using System.Security.Authentication;
+using DataGateVPNBot.Services.BotServices.Interfaces;
+using DataGateVPNBot.Services.DashboardServices.Interfaces;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+
+namespace DataGateVPNBot.Handlers;
+
+public partial class TelegramUpdateHandler
+{
+    private async Task<Message> AdminUnsubscribedVpnUsersDigestAsync(
+        Message msg,
+        CancellationToken cancellationToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var tgUserService = scope.ServiceProvider.GetRequiredService<ITelegramBotUserService>();
+
+        if (!await tgUserService.IsTelegramDashboardAdminAsync(msg.From!.Id, cancellationToken))
+        {
+            return await _botClient.SendMessage(
+                msg.Chat.Id,
+                "⛔ This command is only for bot administrators.",
+                cancellationToken: cancellationToken);
+        }
+
+        await _botClient.SendMessage(
+            msg.Chat.Id,
+            "⏳ Building Free/Default unsubscribed VPN digest…",
+            cancellationToken: cancellationToken);
+
+        try
+        {
+            var digestService = scope.ServiceProvider.GetRequiredService<IFreeTierUnsubscribedVpnDigestBotService>();
+            var text = await digestService.GetDigestTextAsync(cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return await _botClient.SendMessage(
+                    msg.Chat.Id,
+                    "Could not load the digest from the dashboard API.",
+                    cancellationToken: cancellationToken);
+            }
+
+            if (text.Length > 4090)
+                text = text[..4090] + "…";
+
+            return await _botClient.SendMessage(
+                msg.Chat.Id,
+                text,
+                cancellationToken: cancellationToken);
+        }
+        catch (AuthenticationException ex)
+        {
+            _logger.LogWarning(ex, "Admin unsubscribed VPN digest: authentication failed");
+            return await _botClient.SendMessage(
+                msg.Chat.Id,
+                "❌ Dashboard authentication failed. Try again later.",
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Admin unsubscribed VPN digest failed");
+            return await _botClient.SendMessage(
+                msg.Chat.Id,
+                "❌ Failed to load the digest. Check backend logs.",
+                cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.UnsubscribedVpnDigest.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.UnsubscribedVpnDigest.cs
@@ -51,7 +51,7 @@ public partial class TelegramUpdateHandler
             if (liveText.Length > 4090)
                 liveText = liveText[..4090] + "…";
 
-            var keyboard = BuildEmailRemindKeyboard(digest.Candidates);
+            var keyboard = BuildRemindKeyboard(digest.Candidates);
             return await _botClient.SendMessage(
                 msg.Chat.Id,
                 liveText,
@@ -76,32 +76,50 @@ public partial class TelegramUpdateHandler
         }
     }
 
-    public static InlineKeyboardMarkup? BuildEmailRemindKeyboard(
+    /// <summary>
+    /// One row per candidate that can be reminded: optional TG and/or Email buttons.
+    /// </summary>
+    public static InlineKeyboardMarkup? BuildRemindKeyboard(
         IReadOnlyList<FreeTierEnforcementCandidateDto>? candidates)
     {
         if (candidates is null || candidates.Count == 0)
             return null;
 
-        var withEmail = candidates
-            .Where(c => !string.IsNullOrWhiteSpace(c.Email))
+        var actionable = candidates
+            .Where(c => c.TelegramId is > 0 || !string.IsNullOrWhiteSpace(c.Email))
             .OrderBy(c => c.DisplayName)
-            .Take(24)
+            .Take(20)
             .ToList();
-        if (withEmail.Count == 0)
+        if (actionable.Count == 0)
             return null;
 
         var rows = new List<InlineKeyboardButton[]>();
-        const int perRow = 2;
-        for (var i = 0; i < withEmail.Count; i += perRow)
+        foreach (var c in actionable)
         {
-            var chunk = withEmail.Skip(i).Take(perRow)
-                .Select(c => InlineKeyboardButton.WithCallbackData(
+            var buttons = new List<InlineKeyboardButton>(2);
+            if (c.TelegramId is > 0)
+            {
+                buttons.Add(InlineKeyboardButton.WithCallbackData(
+                    $"TG #{c.UserId}",
+                    $"{BotCommands.CommandRemindChannelSubscribe} {c.UserId}"));
+            }
+
+            if (!string.IsNullOrWhiteSpace(c.Email))
+            {
+                buttons.Add(InlineKeyboardButton.WithCallbackData(
                     $"Email #{c.UserId}",
-                    $"{BotCommands.CommandRemindChannelEmail} {c.UserId}"))
-                .ToArray();
-            rows.Add(chunk);
+                    $"{BotCommands.CommandRemindChannelEmail} {c.UserId}"));
+            }
+
+            if (buttons.Count > 0)
+                rows.Add(buttons.ToArray());
         }
 
-        return new InlineKeyboardMarkup(rows);
+        return rows.Count == 0 ? null : new InlineKeyboardMarkup(rows);
     }
+
+    [Obsolete("Use BuildRemindKeyboard")]
+    public static InlineKeyboardMarkup? BuildEmailRemindKeyboard(
+        IReadOnlyList<FreeTierEnforcementCandidateDto>? candidates)
+        => BuildRemindKeyboard(candidates);
 }

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
@@ -291,6 +291,12 @@ public partial class TelegramUpdateHandler(
             _logger.LogInformation("Admin email channel-subscribe remind for userId: {UserId}", userId);
             await AdminRemindChannelEmailFromCallbackAsync(message, callbackQuery.From, userId, cancellationToken);
         }
+        else if (lowerData.StartsWith($"{BotCommands.CommandRemindChannelSubscribe} "))
+        {
+            var target = data.Substring(BotCommands.CommandRemindChannelSubscribe.Length + 1).Trim();
+            _logger.LogInformation("Admin Telegram channel-subscribe remind for target: {Target}", target);
+            await AdminRemindChannelSubscribeFromCallbackAsync(message, callbackQuery.From, target, cancellationToken);
+        }
         else if (data is BotCommands.CommandEnglish or BotCommands.CommandRussian or BotCommands.CommandGreek)
         {
             _logger.LogInformation("User selected language: {Language}", data);

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
@@ -142,7 +142,8 @@ public partial class TelegramUpdateHandler(
             BotCommands.CommandDeleteSelectedFile,
             BotCommands.CommandDeleteAllFiles,
             BotCommands.CommandDashboardApiGetToken,
-            BotCommands.CommandRefreshProfilePhotos
+            BotCommands.CommandRefreshProfilePhotos,
+            BotCommands.CommandUnsubscribedVpnUsers
         };
 
         if (!isPrivate && privateOnlyCommands.Contains(command))
@@ -188,6 +189,7 @@ public partial class TelegramUpdateHandler(
             BotCommands.CommandPollAnonymous => SendAnonymousPoll(msg),
             BotCommands.CommandThrow => FailingHandler(),
             BotCommands.CommandRefreshProfilePhotos => AdminRefreshAllProfilePhotosAsync(msg, cancellationToken),
+            BotCommands.CommandUnsubscribedVpnUsers => AdminUnsubscribedVpnUsersDigestAsync(msg, cancellationToken),
 
             _ => Usage(msg, cancellationToken)
         });

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
@@ -143,7 +143,9 @@ public partial class TelegramUpdateHandler(
             BotCommands.CommandDeleteAllFiles,
             BotCommands.CommandDashboardApiGetToken,
             BotCommands.CommandRefreshProfilePhotos,
-            BotCommands.CommandUnsubscribedVpnUsers
+            BotCommands.CommandUnsubscribedVpnUsers,
+            BotCommands.CommandRemindChannelSubscribe,
+            BotCommands.CommandRemindChannelEmail
         };
 
         if (!isPrivate && privateOnlyCommands.Contains(command))
@@ -190,6 +192,8 @@ public partial class TelegramUpdateHandler(
             BotCommands.CommandThrow => FailingHandler(),
             BotCommands.CommandRefreshProfilePhotos => AdminRefreshAllProfilePhotosAsync(msg, cancellationToken),
             BotCommands.CommandUnsubscribedVpnUsers => AdminUnsubscribedVpnUsersDigestAsync(msg, cancellationToken),
+            BotCommands.CommandRemindChannelSubscribe => AdminRemindChannelSubscribeAsync(msg, argument, cancellationToken),
+            BotCommands.CommandRemindChannelEmail => AdminRemindChannelEmailAsync(msg, argument, cancellationToken),
 
             _ => Usage(msg, cancellationToken)
         });
@@ -280,6 +284,12 @@ public partial class TelegramUpdateHandler(
             var vpnServerId = data.Substring(BotCommands.CommandDeleteAllFiles.Length + 1);
             _logger.LogInformation("Delete all files for vpnServerId: {VpnServerId}", vpnServerId);
             await DeleteAllFiles(message, vpnServerId, cancellationToken);
+        }
+        else if (lowerData.StartsWith($"{BotCommands.CommandRemindChannelEmail} "))
+        {
+            var userId = data.Substring(BotCommands.CommandRemindChannelEmail.Length + 1).Trim();
+            _logger.LogInformation("Admin email channel-subscribe remind for userId: {UserId}", userId);
+            await AdminRemindChannelEmailFromCallbackAsync(message, callbackQuery.From, userId, cancellationToken);
         }
         else if (data is BotCommands.CommandEnglish or BotCommands.CommandRussian or BotCommands.CommandGreek)
         {
@@ -447,15 +457,61 @@ public partial class TelegramUpdateHandler(
 
     private async Task<Message> RegisterCommandsAsync(Message msg, CancellationToken cancellationToken)
     {
-        await _botClient.SetMyCommands(_telegramSettingsService.GetTelegramMenuByLanguage(Language.English), 
-            languageCode: "en", cancellationToken: cancellationToken);
-        await _botClient.SetMyCommands(_telegramSettingsService.GetTelegramMenuByLanguage(Language.Russian), 
-            languageCode: "ru", cancellationToken: cancellationToken);
-        await _botClient.SetMyCommands(_telegramSettingsService.GetTelegramMenuByLanguage(Language.Greek), 
-            languageCode: "el", cancellationToken: cancellationToken);
+        using var scope = _serviceProvider.CreateScope();
+        var tgUserService = scope.ServiceProvider.GetRequiredService<ITelegramBotUserService>();
+
+        long[] adminTelegramIds = [];
+        try
+        {
+            var admins = await tgUserService.GetAdminsAsync(cancellationToken);
+            adminTelegramIds = admins.TelegramBotAdmins?
+                .Select(a => a.TelegramId)
+                .Where(id => id > 0)
+                .Distinct()
+                .ToArray() ?? [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not load dashboard admins for scoped command registration");
+        }
+
+        (Language Language, string Code)[] languages =
+        [
+            (Language.English, "en"),
+            (Language.Russian, "ru"),
+            (Language.Greek, "el"),
+        ];
+
+        foreach (var (language, code) in languages)
+        {
+            var publicCommands = _telegramSettingsService.GetTelegramMenuByLanguage(language);
+            var adminCommands = _telegramSettingsService.GetTelegramMenuByLanguage(language, includeAdminCommands: true);
+
+            // Default scope: visible to everyone — no admin-only commands.
+            await _botClient.SetMyCommands(
+                publicCommands,
+                scope: BotCommandScope.Default(),
+                languageCode: code,
+                cancellationToken: cancellationToken);
+
+            // Per-admin private chat scope: full menu including admin tools.
+            foreach (var adminId in adminTelegramIds)
+            {
+                await _botClient.SetMyCommands(
+                    adminCommands,
+                    scope: BotCommandScope.Chat(adminId),
+                    languageCode: code,
+                    cancellationToken: cancellationToken);
+            }
+        }
+
+        var adminNote = adminTelegramIds.Length == 0
+            ? " Admin commands were not scoped (no admins loaded)."
+            : $" Admin commands scoped to {adminTelegramIds.Length} admin chat(s).";
+
         return await _botClient.SendMessage(
             chatId: msg.Chat.Id,
-            text: "\u2705 All commands have been successfully registered...",
+            text: "\u2705 All commands have been successfully registered..." + adminNote,
             replyMarkup: new ReplyKeyboardRemove(), cancellationToken: cancellationToken);
     }
     

--- a/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
+++ b/DataGateVPNBot/Handlers/TelegramUpdateHandler.cs
@@ -66,10 +66,21 @@ public partial class TelegramUpdateHandler(
             { ChosenInlineResult: { } chosenInlineResult } => OnChosenInlineResult(chosenInlineResult),
             { Poll: { } poll } => OnPoll(poll),
             { PollAnswer: { } pollAnswer } => OnPollAnswer(pollAnswer),
-            // ChannelPost:
-            // EditedChannelPost:
-            // ShippingQuery:
-            // PreCheckoutQuery:
+            { ChatBoost: { } chatBoost } => OnChatBoostUpdateAsync(chatBoost, cancellationToken),
+            { RemovedChatBoost: { } removedChatBoost } => OnRemovedChatBoostUpdateAsync(removedChatBoost, cancellationToken),
+            { ChatJoinRequest: { } chatJoinRequest } => OnChatJoinRequestUpdateAsync(chatJoinRequest, cancellationToken),
+            { MessageReaction: { } messageReaction } => OnMessageReactionUpdateAsync(messageReaction, cancellationToken),
+            { MessageReactionCount: { } messageReactionCount } => OnMessageReactionCountUpdateAsync(messageReactionCount, cancellationToken),
+            { BusinessConnection: { } businessConnection } => OnBusinessConnectionUpdateAsync(businessConnection, cancellationToken),
+            { BusinessMessage: { } businessMessage } => OnUnsupportedChannelUpdateAsync("BusinessMessage", businessMessage, cancellationToken),
+            { EditedBusinessMessage: { } editedBusinessMessage } => OnUnsupportedChannelUpdateAsync("EditedBusinessMessage", editedBusinessMessage, cancellationToken),
+            { DeletedBusinessMessages: { } deletedBusinessMessages } => OnDeletedBusinessMessagesUpdateAsync(deletedBusinessMessages, cancellationToken),
+            { GuestMessage: { } guestMessage } => OnUnsupportedChannelUpdateAsync("GuestMessage", guestMessage, cancellationToken),
+            { ShippingQuery: { } shippingQuery } => OnShippingQueryUpdateAsync(shippingQuery, cancellationToken),
+            { PreCheckoutQuery: { } preCheckoutQuery } => OnPreCheckoutQueryUpdateAsync(preCheckoutQuery, cancellationToken),
+            { PurchasedPaidMedia: { } purchasedPaidMedia } => OnPurchasedPaidMediaUpdateAsync(purchasedPaidMedia, cancellationToken),
+            { ManagedBot: { } managedBot } => OnManagedBotUpdateAsync(managedBot, cancellationToken),
+            { Subscription: { } subscription } => OnSubscriptionUpdateAsync(subscription, cancellationToken),
             _ => UnknownUpdateHandlerAsync(update, cancellationToken)
         });
     }
@@ -313,19 +324,28 @@ public partial class TelegramUpdateHandler(
         var chat = DescribeChat(message.Chat);
         var actor = DescribeUser(message.From);
         var payload = string.IsNullOrWhiteSpace(message.Text)
-            ? "<empty>"
+            ? "—"
             : message.Text.Length > 500
-                ? message.Text[..500] + "... (truncated)"
+                ? message.Text[..500] + "…"
                 : message.Text;
 
+        var title = updateType switch
+        {
+            "ChannelPost" => "Channel post",
+            "EditedChannelPost" => "Channel post edited",
+            "BusinessMessage" => "Business message",
+            "EditedBusinessMessage" => "Business message edited",
+            "GuestMessage" => "Guest message",
+            _ => updateType
+        };
+
         var text =
-            "ℹ️ Unsupported Telegram update received\n" +
+            $"ℹ️ {title}\n" +
             $"Type: {updateType}\n" +
-            "Status: currently not supported by this bot\n" +
             $"Chat: {chat}\n" +
-            $"Actor: {actor}\n" +
+            $"User: {actor}\n" +
             $"MessageId: {message.Id}\n" +
-            $"Payload: {payload}\n" +
+            $"Text: {payload}\n" +
             $"Time: {DateTimeOffset.UtcNow:yyyy-MM-dd HH:mm:ss} UTC";
 
         _logger.LogInformation("Unsupported update {UpdateType} received. Chat={Chat}; MessageId={MessageId}",

--- a/DataGateVPNBot/Localization/ApiErrorMessageMapper.cs
+++ b/DataGateVPNBot/Localization/ApiErrorMessageMapper.cs
@@ -1,0 +1,124 @@
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+
+namespace DataGateVPNBot.Localization;
+
+/// <summary>
+/// Maps dashboard API machine messages (and legacy English strings) to LocalizationTexts keys.
+/// </summary>
+public static partial class ApiErrorMessageMapper
+{
+    public const string TelegramAlreadyLinkedToGooglePrefix = "TelegramAlreadyLinkedToGoogle|";
+    public const string VpnServerNotAllowedByQuotaPlanKey = "VpnServerNotAllowedByQuotaPlan";
+
+    public const string LocalizationAccountLinkTelegramAlreadyLinkedToGoogle =
+        "AccountLinkTelegramAlreadyLinkedToGoogle";
+
+    public const string LocalizationVpnServerNotAllowedByQuotaPlan = "VpnServerNotAllowedByQuotaPlan";
+
+    public sealed record MappedError(
+        string LocalizationKey,
+        IReadOnlyDictionary<string, string>? Placeholders,
+        bool IsExpectedBusinessError);
+
+    public static bool TryMap(string? apiOrExceptionMessage, out MappedError mapped)
+    {
+        mapped = null!;
+        var message = ExtractPrimaryMessage(apiOrExceptionMessage);
+        if (string.IsNullOrWhiteSpace(message))
+            return false;
+
+        if (message.StartsWith(TelegramAlreadyLinkedToGooglePrefix, StringComparison.Ordinal))
+        {
+            var label = message[TelegramAlreadyLinkedToGooglePrefix.Length..];
+            mapped = new MappedError(
+                LocalizationAccountLinkTelegramAlreadyLinkedToGoogle,
+                new Dictionary<string, string> { ["accountLabel"] = label },
+                IsExpectedBusinessError: true);
+            return true;
+        }
+
+        if (IsVpnServerNotAllowedByQuotaPlan(message))
+        {
+            mapped = new MappedError(
+                LocalizationVpnServerNotAllowedByQuotaPlan,
+                Placeholders: null,
+                IsExpectedBusinessError: true);
+            return true;
+        }
+
+        return false;
+    }
+
+    public static string ExtractPrimaryMessage(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return string.Empty;
+
+        foreach (Match match in ResponseBodyRegex().Matches(raw))
+        {
+            var json = match.Groups[1].Value.Trim();
+            if (TryReadMessageFromJson(json, out var fromJson))
+                return fromJson;
+        }
+
+        var trimmed = raw.Trim();
+        if (trimmed.StartsWith('{') && TryReadMessageFromJson(trimmed, out var direct))
+            return direct;
+
+        return FirstMeaningfulLine(trimmed);
+    }
+
+    private static bool IsVpnServerNotAllowedByQuotaPlan(string message)
+    {
+        if (string.Equals(message, VpnServerNotAllowedByQuotaPlanKey, StringComparison.Ordinal))
+            return true;
+
+        if (message.Contains("Access to this VPN server is denied for your quota plan", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return message.Contains("not allowed", StringComparison.OrdinalIgnoreCase)
+               && message.Contains("active quota plan", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryReadMessageFromJson(string json, out string message)
+    {
+        message = string.Empty;
+        try
+        {
+            var token = JToken.Parse(json);
+            var value = token["message"]?.ToString();
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+            message = value.Trim();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string FirstMeaningfulLine(string text)
+    {
+        using var reader = new StringReader(text);
+        while (reader.ReadLine() is { } line)
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0)
+                continue;
+            if (trimmed.StartsWith("Failed to complete HTTP request", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (trimmed.StartsWith("Attempt ", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (trimmed.StartsWith("Response body:", StringComparison.OrdinalIgnoreCase))
+                continue;
+            return trimmed;
+        }
+
+        return text.Trim();
+    }
+
+    [GeneratedRegex(@"Response body:\s*(\{.*?\})(?=\r?\n|$)", RegexOptions.Singleline)]
+    private static partial Regex ResponseBodyRegex();
+}

--- a/DataGateVPNBot/Services/BotServices/FreeTierAccessComplianceBotService.cs
+++ b/DataGateVPNBot/Services/BotServices/FreeTierAccessComplianceBotService.cs
@@ -1,8 +1,11 @@
 using System.Security.Authentication;
+using DataGateVPNBot.Localization;
 using DataGateVPNBot.Models.Configurations;
 using DataGateVPNBot.Services.BotServices.Interfaces;
 using DataGateVPNBot.Services.DashboardServices;
+using DataGateVPNBot.Services.DashboardServices.Interfaces;
 using DataGateVPNBot.Services.Http;
+using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotLocalization.Requests;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Telegram.Bot;
@@ -16,8 +19,11 @@ public sealed class FreeTierAccessComplianceBotService(
     IOptions<BotConfiguration> botOptions,
     AuthService authService,
     IHttpRequestService httpRequestService,
+    ILocalizationService localizationService,
     ILogger<FreeTierAccessComplianceBotService> logger) : IFreeTierAccessComplianceBotService
 {
+    public const string AccessDeniedLocalizationKey = "FreeTierAccessDenied";
+
     private const string AuditEndpointPrefix = "api/users/audit-free-tier-access/by-telegram/";
 
     public static string BuildAuditEndpoint(long telegramId, bool? channelSubscribed, string? context = null)
@@ -36,13 +42,26 @@ public sealed class FreeTierAccessComplianceBotService(
         return $"{endpoint}{separator}context={Uri.EscapeDataString(context)}";
     }
 
-    public string BuildAccessDeniedMessage()
+    public async Task<string> BuildAccessDeniedMessageAsync(long telegramId, CancellationToken cancellationToken)
     {
         var channel = botOptions.Value.RequiredChannelChatId;
-        return $"Для тарифа Free/Default нужна подписка на канал {channel}.\n" +
-               $"Подпишитесь на канал и повторите запрос.\n\n" +
-               $"Free/Default access requires subscription to {channel}.\n" +
-               $"Please subscribe to the channel and try again.";
+        var channelUrl = botOptions.Value.RequiredChannelUrl;
+        var response = await localizationService.GetTextForTelegramUser(
+            new GetTextForTelegramUserRequest
+            {
+                TelegramId = telegramId > 0 ? telegramId : 0,
+                Key = AccessDeniedLocalizationKey,
+            },
+            cancellationToken);
+
+        var template = response.Text;
+        return LocalizationPlaceholderFormatter.Apply(
+            template,
+            new Dictionary<string, string>
+            {
+                ["channel"] = channel,
+                ["channelUrl"] = channelUrl,
+            });
     }
 
     public async Task<bool?> IsSubscribedToRequiredChannelAsync(long telegramId, CancellationToken cancellationToken)
@@ -56,6 +75,15 @@ public sealed class FreeTierAccessComplianceBotService(
             var member = await botClient.GetChatMember(chatId, telegramId, cancellationToken);
             return IsActiveMember(member);
         }
+        catch (Exception ex) when (IsExpectedNonMembershipError(ex))
+        {
+            logger.LogDebug(
+                ex,
+                "Telegram user {TelegramId} is not a member of {Channel} (expected getChatMember response)",
+                telegramId,
+                botOptions.Value.RequiredChannelChatId);
+            return false;
+        }
         catch (Exception ex)
         {
             logger.LogWarning(
@@ -67,13 +95,28 @@ public sealed class FreeTierAccessComplianceBotService(
         }
     }
 
+    public static bool IsExpectedNonMembershipError(Exception ex)
+    {
+        var text = ex.Message;
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        var lower = text.ToLowerInvariant();
+        return lower.Contains("participant_id_invalid", StringComparison.Ordinal)
+               || lower.Contains("user not found", StringComparison.Ordinal)
+               || lower.Contains("member not found", StringComparison.Ordinal)
+               || lower.Contains("user is deactivated", StringComparison.Ordinal)
+               || lower.Contains("user_deactivated", StringComparison.Ordinal)
+               || lower.Contains("peer_id_invalid", StringComparison.Ordinal);
+    }
+
     public async Task<VpnAccessGateResult> EnsureVpnAccessAsync(
         long telegramId,
         string context,
         CancellationToken cancellationToken)
     {
         if (telegramId <= 0)
-            return VpnAccessGateResult.Denied(BuildAccessDeniedMessage());
+            return VpnAccessGateResult.Denied(await BuildAccessDeniedMessageAsync(0, cancellationToken));
 
         var channelSubscribed = await IsSubscribedToRequiredChannelAsync(telegramId, cancellationToken);
         if (channelSubscribed == true)
@@ -108,7 +151,7 @@ public sealed class FreeTierAccessComplianceBotService(
                 response?.Message);
         }
 
-        return VpnAccessGateResult.Denied(BuildAccessDeniedMessage());
+        return VpnAccessGateResult.Denied(await BuildAccessDeniedMessageAsync(telegramId, cancellationToken));
     }
 
     public static bool IsActiveMember(ChatMember member)

--- a/DataGateVPNBot/Services/BotServices/FreeTierAccessComplianceBotService.cs
+++ b/DataGateVPNBot/Services/BotServices/FreeTierAccessComplianceBotService.cs
@@ -39,10 +39,10 @@ public sealed class FreeTierAccessComplianceBotService(
     public string BuildAccessDeniedMessage()
     {
         var channel = botOptions.Value.RequiredChannelChatId;
-        return $"Для тарифа Free/Default нужна подписка на канал {channel} или связанный аккаунт (Telegram + Google/пароль).\n" +
-               $"Подпишитесь на канал или получите код связки в приложении и отправьте /link_account КОД.\n\n" +
-               $"Free/Default access requires subscription to {channel} or a linked account (Telegram + Google/password).\n" +
-               $"Subscribe to the channel, or request a link code in the app and send /link_account CODE.";
+        return $"Для тарифа Free/Default нужна подписка на канал {channel}.\n" +
+               $"Подпишитесь на канал и повторите запрос.\n\n" +
+               $"Free/Default access requires subscription to {channel}.\n" +
+               $"Please subscribe to the channel and try again.";
     }
 
     public async Task<bool?> IsSubscribedToRequiredChannelAsync(long telegramId, CancellationToken cancellationToken)

--- a/DataGateVPNBot/Services/BotServices/FreeTierChannelSubscribeRemindBotService.cs
+++ b/DataGateVPNBot/Services/BotServices/FreeTierChannelSubscribeRemindBotService.cs
@@ -1,0 +1,57 @@
+using System.Security.Authentication;
+using DataGateVPNBot.Services.BotServices.Interfaces;
+using DataGateVPNBot.Services.DashboardServices;
+using DataGateVPNBot.Services.Http;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Enums;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
+using DataGateMonitor.SharedModels.Responses;
+
+namespace DataGateVPNBot.Services.BotServices;
+
+public sealed class FreeTierChannelSubscribeRemindBotService(
+    AuthService authService,
+    IHttpRequestService httpRequestService,
+    ILogger<FreeTierChannelSubscribeRemindBotService> logger) : IFreeTierChannelSubscribeRemindBotService
+{
+    private const string EndpointPrefix = "api/free-tier-enforcement/remind-channel-subscribe/";
+
+    public async Task<FreeTierChannelSubscribeRemindResponse> RemindAsync(
+        string target,
+        FreeTierChannelSubscribeRemindChannel channel,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            return FreeTierChannelSubscribeRemindResponse.Fail(
+                channel,
+                channel == FreeTierChannelSubscribeRemindChannel.Email
+                    ? "Usage: /remind_channel_email <userId>"
+                    : "Usage: /remind_channel_subscribe <userId|telegramId>");
+        }
+
+        var token = await authService.GetTokenAsync();
+        if (string.IsNullOrEmpty(token))
+            throw new AuthenticationException("Authentication failed. Failed to obtain a valid token from API.");
+
+        var endpoint =
+            $"{EndpointPrefix}{Uri.EscapeDataString(target.Trim())}?channel={Uri.EscapeDataString(channel.ToString())}";
+        var response = await httpRequestService.PostAsync<ApiResponse<FreeTierChannelSubscribeRemindResponse>>(
+            endpoint,
+            new { },
+            token,
+            cancellationToken);
+
+        if (response is { Success: true, Data: not null })
+            return response.Data;
+
+        var message = response?.Message ?? "null response";
+        logger.LogWarning(
+            "Channel-subscribe remind API failed for {Target} channel={Channel}: {Message}",
+            target,
+            channel,
+            message);
+        return FreeTierChannelSubscribeRemindResponse.Fail(
+            channel,
+            string.IsNullOrWhiteSpace(message) ? "Failed to send reminder." : message);
+    }
+}

--- a/DataGateVPNBot/Services/BotServices/FreeTierUnsubscribedVpnDigestBotService.cs
+++ b/DataGateVPNBot/Services/BotServices/FreeTierUnsubscribedVpnDigestBotService.cs
@@ -1,0 +1,31 @@
+using System.Security.Authentication;
+using DataGateVPNBot.Services.BotServices.Interfaces;
+using DataGateVPNBot.Services.DashboardServices;
+using DataGateVPNBot.Services.Http;
+using DataGateMonitor.SharedModels.Responses;
+
+namespace DataGateVPNBot.Services.BotServices;
+
+public sealed class FreeTierUnsubscribedVpnDigestBotService(
+    AuthService authService,
+    IHttpRequestService httpRequestService,
+    ILogger<FreeTierUnsubscribedVpnDigestBotService> logger) : IFreeTierUnsubscribedVpnDigestBotService
+{
+    private const string Endpoint = "api/free-tier-enforcement/unsubscribed-vpn-digest";
+
+    public async Task<string?> GetDigestTextAsync(CancellationToken cancellationToken)
+    {
+        var token = await authService.GetTokenAsync();
+        if (string.IsNullOrEmpty(token))
+            throw new AuthenticationException("Authentication failed. Failed to obtain a valid token from API.");
+
+        var response = await httpRequestService.GetAsync<ApiResponse<string>>(Endpoint, token, cancellationToken);
+        if (response is { Success: true, Data: not null })
+            return response.Data;
+
+        logger.LogWarning(
+            "Unsubscribed VPN digest API failed: {Message}",
+            response?.Message ?? "null response");
+        return null;
+    }
+}

--- a/DataGateVPNBot/Services/BotServices/FreeTierUnsubscribedVpnDigestBotService.cs
+++ b/DataGateVPNBot/Services/BotServices/FreeTierUnsubscribedVpnDigestBotService.cs
@@ -2,6 +2,7 @@ using System.Security.Authentication;
 using DataGateVPNBot.Services.BotServices.Interfaces;
 using DataGateVPNBot.Services.DashboardServices;
 using DataGateVPNBot.Services.Http;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
 using DataGateMonitor.SharedModels.Responses;
 
 namespace DataGateVPNBot.Services.BotServices;
@@ -13,13 +14,14 @@ public sealed class FreeTierUnsubscribedVpnDigestBotService(
 {
     private const string Endpoint = "api/free-tier-enforcement/unsubscribed-vpn-digest";
 
-    public async Task<string?> GetDigestTextAsync(CancellationToken cancellationToken)
+    public async Task<FreeTierUnsubscribedVpnDigestResponse?> GetDigestAsync(CancellationToken cancellationToken)
     {
         var token = await authService.GetTokenAsync();
         if (string.IsNullOrEmpty(token))
             throw new AuthenticationException("Authentication failed. Failed to obtain a valid token from API.");
 
-        var response = await httpRequestService.GetAsync<ApiResponse<string>>(Endpoint, token, cancellationToken);
+        var response = await httpRequestService.GetAsync<ApiResponse<FreeTierUnsubscribedVpnDigestResponse>>(
+            Endpoint, token, cancellationToken);
         if (response is { Success: true, Data: not null })
             return response.Data;
 

--- a/DataGateVPNBot/Services/BotServices/Interfaces/IFreeTierChannelSubscribeRemindBotService.cs
+++ b/DataGateVPNBot/Services/BotServices/Interfaces/IFreeTierChannelSubscribeRemindBotService.cs
@@ -1,0 +1,12 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Enums;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
+
+namespace DataGateVPNBot.Services.BotServices.Interfaces;
+
+public interface IFreeTierChannelSubscribeRemindBotService
+{
+    Task<FreeTierChannelSubscribeRemindResponse> RemindAsync(
+        string target,
+        FreeTierChannelSubscribeRemindChannel channel,
+        CancellationToken cancellationToken);
+}

--- a/DataGateVPNBot/Services/BotServices/Interfaces/IFreeTierUnsubscribedVpnDigestBotService.cs
+++ b/DataGateVPNBot/Services/BotServices/Interfaces/IFreeTierUnsubscribedVpnDigestBotService.cs
@@ -1,9 +1,8 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
+
 namespace DataGateVPNBot.Services.BotServices.Interfaces;
 
 public interface IFreeTierUnsubscribedVpnDigestBotService
 {
-    /// <summary>
-    /// Fetches the on-demand unsubscribed VPN digest text from the dashboard API.
-    /// </summary>
-    Task<string?> GetDigestTextAsync(CancellationToken cancellationToken);
+    Task<FreeTierUnsubscribedVpnDigestResponse?> GetDigestAsync(CancellationToken cancellationToken);
 }

--- a/DataGateVPNBot/Services/BotServices/Interfaces/IFreeTierUnsubscribedVpnDigestBotService.cs
+++ b/DataGateVPNBot/Services/BotServices/Interfaces/IFreeTierUnsubscribedVpnDigestBotService.cs
@@ -1,0 +1,9 @@
+namespace DataGateVPNBot.Services.BotServices.Interfaces;
+
+public interface IFreeTierUnsubscribedVpnDigestBotService
+{
+    /// <summary>
+    /// Fetches the on-demand unsubscribed VPN digest text from the dashboard API.
+    /// </summary>
+    Task<string?> GetDigestTextAsync(CancellationToken cancellationToken);
+}

--- a/DataGateVPNBot/Services/BotServices/Interfaces/ITelegramProfilePhotoDownloader.cs
+++ b/DataGateVPNBot/Services/BotServices/Interfaces/ITelegramProfilePhotoDownloader.cs
@@ -1,0 +1,12 @@
+namespace DataGateVPNBot.Services.BotServices.Interfaces;
+
+public interface ITelegramProfilePhotoDownloader
+{
+    /// <summary>
+    /// Downloads the largest current profile photo for <paramref name="telegramId"/>.
+    /// Returns null when missing or inaccessible.
+    /// </summary>
+    Task<(byte[] Bytes, string? FileUniqueId)?> TryDownloadAsync(
+        long telegramId,
+        CancellationToken cancellationToken = default);
+}

--- a/DataGateVPNBot/Services/BotServices/Interfaces/ITelegramSettingsService.cs
+++ b/DataGateVPNBot/Services/BotServices/Interfaces/ITelegramSettingsService.cs
@@ -5,5 +5,9 @@ namespace DataGateVPNBot.Services.BotServices.Interfaces;
 
 public interface ITelegramSettingsService
 {
-    BotCommand[] GetTelegramMenuByLanguage(Language language);
+    /// <param name="includeAdminCommands">
+    /// When false (default), only end-user commands are returned for the public bot menu.
+    /// Admin-only commands must be registered with <c>BotCommandScopeChat</c> per admin.
+    /// </param>
+    BotCommand[] GetTelegramMenuByLanguage(Language language, bool includeAdminCommands = false);
 }

--- a/DataGateVPNBot/Services/BotServices/Interfaces/ITelegramUserProfilePhotoRefreshService.cs
+++ b/DataGateVPNBot/Services/BotServices/Interfaces/ITelegramUserProfilePhotoRefreshService.cs
@@ -7,4 +7,13 @@ public interface ITelegramUserProfilePhotoRefreshService
     /// and upserts it via <c>POST api/tgbot-users/profile-photo</c>.
     /// </summary>
     Task<ProfilePhotoBatchRefreshResult> RefreshAllFromTelegramAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Downloads the current profile photo for a single Telegram user (largest size).
+    /// Returns null when the user has no photo or Telegram refuses access. Optionally upserts to the dashboard.
+    /// </summary>
+    Task<byte[]?> TryDownloadProfilePhotoAsync(
+        long telegramId,
+        bool upsertToDashboard = false,
+        CancellationToken cancellationToken = default);
 }

--- a/DataGateVPNBot/Services/BotServices/TelegramProfilePhotoDownloader.cs
+++ b/DataGateVPNBot/Services/BotServices/TelegramProfilePhotoDownloader.cs
@@ -1,0 +1,50 @@
+using DataGateVPNBot.Services.BotServices.Interfaces;
+using Telegram.Bot;
+
+namespace DataGateVPNBot.Services.BotServices;
+
+public sealed class TelegramProfilePhotoDownloader(
+    ILogger<TelegramProfilePhotoDownloader> logger,
+    ITelegramBotClient botClient) : ITelegramProfilePhotoDownloader
+{
+    public async Task<(byte[] Bytes, string? FileUniqueId)?> TryDownloadAsync(
+        long telegramId,
+        CancellationToken cancellationToken = default)
+    {
+        if (telegramId <= 0)
+            return null;
+
+        try
+        {
+            var photos = await botClient.GetUserProfilePhotos(telegramId, offset: 0, limit: 1, cancellationToken);
+            if (photos.TotalCount == 0 || photos.Photos.Length == 0)
+                return null;
+
+            var sizes = photos.Photos[^1];
+            if (sizes.Length == 0)
+                return null;
+
+            var biggest = sizes[^1];
+            await using var ms = new MemoryStream();
+            await botClient.GetInfoAndDownloadFile(biggest.FileId, ms, cancellationToken);
+            var bytes = ms.ToArray();
+            if (bytes.Length == 0)
+                return null;
+
+            var uniqueId = string.IsNullOrEmpty(biggest.FileUniqueId) ? null : biggest.FileUniqueId;
+            return (bytes, uniqueId);
+        }
+        catch (Exception ex) when (TelegramProfilePhotoAccessHelper.IsUserUnavailableForBot(ex))
+        {
+            logger.LogInformation(
+                "No profile photo for TelegramId {Id}: user unavailable ({Message})",
+                telegramId, ex.Message);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to download profile photo for TelegramId {Id}", telegramId);
+            return null;
+        }
+    }
+}

--- a/DataGateVPNBot/Services/BotServices/TelegramSettingsService.cs
+++ b/DataGateVPNBot/Services/BotServices/TelegramSettingsService.cs
@@ -8,7 +8,7 @@ namespace DataGateVPNBot.Services.BotServices;
 
 public class TelegramSettingsService : ITelegramSettingsService
 {
-    private static readonly LocalizedBotCommand[] AllCommands =
+    private static readonly LocalizedBotCommand[] UserCommands =
     [
         new()
         {
@@ -120,6 +120,10 @@ public class TelegramSettingsService : ITelegramSettingsService
                 ["el"] = "Σύνδεση λογαριασμού εφαρμογής με κωδικό από τον client"
             }
         },
+    ];
+
+    private static readonly LocalizedBotCommand[] AdminCommands =
+    [
         new()
         {
             Command = BotCommands.CommandRefreshProfilePhotos,
@@ -139,10 +143,30 @@ public class TelegramSettingsService : ITelegramSettingsService
                 ["ru"] = "Админ: список Free/Default VPN без подписки на канал",
                 ["el"] = "Διαχειριστής: λίστα Free/Default VPN χωρίς συνδρομή καναλιού"
             }
+        },
+        new()
+        {
+            Command = BotCommands.CommandRemindChannelSubscribe,
+            Descriptions = new()
+            {
+                ["en"] = "Admin: remind a user to subscribe to the required channel",
+                ["ru"] = "Админ: напомнить пользователю подписаться на канал",
+                ["el"] = "Διαχειριστής: υπενθύμιση εγγραφής στο κανάλι"
+            }
+        },
+        new()
+        {
+            Command = BotCommands.CommandRemindChannelEmail,
+            Descriptions = new()
+            {
+                ["en"] = "Admin: email a user to subscribe to the required channel",
+                ["ru"] = "Админ: отправить email с просьбой подписаться на канал",
+                ["el"] = "Διαχειριστής: email υπενθύμισης εγγραφής στο κανάλι"
+            }
         }
     ];
 
-    public BotCommand[] GetTelegramMenuByLanguage(Language language)
+    public BotCommand[] GetTelegramMenuByLanguage(Language language, bool includeAdminCommands = false)
     {
         var langCode = language switch
         {
@@ -152,6 +176,10 @@ public class TelegramSettingsService : ITelegramSettingsService
             _ => throw new ArgumentOutOfRangeException(nameof(language), language, null)
         };
 
-        return AllCommands.Select(c => c.ToTelegramCommand(langCode)).ToArray();
+        IEnumerable<LocalizedBotCommand> source = UserCommands;
+        if (includeAdminCommands)
+            source = UserCommands.Concat(AdminCommands);
+
+        return source.Select(c => c.ToTelegramCommand(langCode)).ToArray();
     }
 }

--- a/DataGateVPNBot/Services/BotServices/TelegramSettingsService.cs
+++ b/DataGateVPNBot/Services/BotServices/TelegramSettingsService.cs
@@ -129,6 +129,16 @@ public class TelegramSettingsService : ITelegramSettingsService
                 ["ru"] = "Админ: обновить аватарки всех пользователей в панели",
                 ["el"] = "Διαχειριστής: συγχρονισμός φωτογραφιών προφίλ όλων των χρηστών"
             }
+        },
+        new()
+        {
+            Command = BotCommands.CommandUnsubscribedVpnUsers,
+            Descriptions = new()
+            {
+                ["en"] = "Admin: list Free/Default VPN users without channel subscription",
+                ["ru"] = "Админ: список Free/Default VPN без подписки на канал",
+                ["el"] = "Διαχειριστής: λίστα Free/Default VPN χωρίς συνδρομή καναλιού"
+            }
         }
     ];
 

--- a/DataGateVPNBot/Services/BotServices/TelegramUserProfilePhotoRefreshService.cs
+++ b/DataGateVPNBot/Services/BotServices/TelegramUserProfilePhotoRefreshService.cs
@@ -3,7 +3,6 @@ using DataGateVPNBot.Services.DashboardServices.Interfaces;
 using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Responses.Dto;
 using Microsoft.Extensions.Options;
-using Telegram.Bot;
 using Telegram.Bot.Exceptions;
 using ProfilePhotoRefreshOptions = DataGateVPNBot.Models.Configurations.ProfilePhotoRefreshOptions;
 
@@ -11,7 +10,7 @@ namespace DataGateVPNBot.Services.BotServices;
 
 public sealed class TelegramUserProfilePhotoRefreshService(
     ILogger<TelegramUserProfilePhotoRefreshService> logger,
-    ITelegramBotClient botClient,
+    ITelegramProfilePhotoDownloader profilePhotoDownloader,
     ITelegramBotUserService telegramBotUserService,
     IOptions<ProfilePhotoRefreshOptions> options)
     : ITelegramUserProfilePhotoRefreshService
@@ -48,26 +47,8 @@ public sealed class TelegramUserProfilePhotoRefreshService(
 
             try
             {
-                var photos = await botClient.GetUserProfilePhotos(user.TelegramId, offset: 0, limit: 1,
-                    cancellationToken);
-                if (photos.TotalCount == 0 || photos.Photos.Length == 0)
-                {
-                    skipped++;
-                    continue;
-                }
-
-                var sizes = photos.Photos[^1];
-                if (sizes.Length == 0)
-                {
-                    skipped++;
-                    continue;
-                }
-
-                var biggest = sizes[^1];
-                await using var ms = new MemoryStream();
-                await botClient.GetInfoAndDownloadFile(biggest.FileId, ms, cancellationToken);
-                var bytes = ms.ToArray();
-                if (bytes.Length == 0)
+                var downloaded = await profilePhotoDownloader.TryDownloadAsync(user.TelegramId, cancellationToken);
+                if (downloaded is null)
                 {
                     skipped++;
                     continue;
@@ -76,9 +57,9 @@ public sealed class TelegramUserProfilePhotoRefreshService(
                 var request = new UpsertTelegramBotUserProfilePhotoRequest
                 {
                     TelegramId = user.TelegramId,
-                    ProfilePhotoBase64 = Convert.ToBase64String(bytes),
+                    ProfilePhotoBase64 = Convert.ToBase64String(downloaded.Value.Bytes),
                     ProfilePhotoMimeType = "image/jpeg",
-                    ProfilePhotoFileUniqueId = string.IsNullOrEmpty(biggest.FileUniqueId) ? null : biggest.FileUniqueId
+                    ProfilePhotoFileUniqueId = downloaded.Value.FileUniqueId
                 };
 
                 var upsert = await telegramBotUserService.UpsertProfilePhotoAsync(request, cancellationToken);
@@ -125,6 +106,33 @@ public sealed class TelegramUserProfilePhotoRefreshService(
             Failed = failed,
             Errors = errors
         };
+    }
+
+    public async Task<byte[]?> TryDownloadProfilePhotoAsync(
+        long telegramId,
+        bool upsertToDashboard = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (telegramId <= 0)
+            return null;
+
+        var downloaded = await profilePhotoDownloader.TryDownloadAsync(telegramId, cancellationToken);
+        if (downloaded is null)
+            return null;
+
+        if (upsertToDashboard)
+        {
+            var request = new UpsertTelegramBotUserProfilePhotoRequest
+            {
+                TelegramId = telegramId,
+                ProfilePhotoBase64 = Convert.ToBase64String(downloaded.Value.Bytes),
+                ProfilePhotoMimeType = "image/jpeg",
+                ProfilePhotoFileUniqueId = downloaded.Value.FileUniqueId
+            };
+            await telegramBotUserService.UpsertProfilePhotoAsync(request, cancellationToken);
+        }
+
+        return downloaded.Value.Bytes;
     }
 
     private static void AppendError(List<string> errors, long telegramId, string message)

--- a/DataGateVPNBot/Services/DashboardServices/AuthService.cs
+++ b/DataGateVPNBot/Services/DashboardServices/AuthService.cs
@@ -155,15 +155,16 @@ public class AuthService(
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to complete account link for TelegramId {TelegramId}", telegramId);
-            var extracted = ApiErrorMessageMapper.ExtractPrimaryMessage(ex.Message);
-            var message = ApiErrorMessageMapper.TryMap(extracted, out _)
-                || ApiErrorMessageMapper.TryMap(ex.Message, out _)
-                ? extracted
-                : "Could not reach the server. Try again later.";
+            var primary = ApiErrorMessageMapper.ExtractPrimaryMessage(ex.Message);
+            if (string.IsNullOrWhiteSpace(primary))
+                primary = ex.Message;
+
             return new CompleteTelegramAccountLinkResponse
             {
                 Success = false,
-                Message = message,
+                Message = ApiErrorMessageMapper.TryMap(primary, out _)
+                    ? primary
+                    : "Could not reach the server. Try again later.",
             };
         }
     }

--- a/DataGateVPNBot/Services/DashboardServices/AuthService.cs
+++ b/DataGateVPNBot/Services/DashboardServices/AuthService.cs
@@ -1,3 +1,4 @@
+using DataGateVPNBot.Localization;
 using DataGateVPNBot.Services.Http;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
@@ -154,10 +155,15 @@ public class AuthService(
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to complete account link for TelegramId {TelegramId}", telegramId);
+            var extracted = ApiErrorMessageMapper.ExtractPrimaryMessage(ex.Message);
+            var message = ApiErrorMessageMapper.TryMap(extracted, out _)
+                || ApiErrorMessageMapper.TryMap(ex.Message, out _)
+                ? extracted
+                : "Could not reach the server. Try again later.";
             return new CompleteTelegramAccountLinkResponse
             {
                 Success = false,
-                Message = "Could not reach the server. Try again later.",
+                Message = message,
             };
         }
     }

--- a/DataGateVPNBot/Services/DashboardServices/OvpnFileService.cs
+++ b/DataGateVPNBot/Services/DashboardServices/OvpnFileService.cs
@@ -244,20 +244,7 @@ public class OvpnFileService(
         var response =
             await httpRequestService.PostAsync<ApiResponse<OvpnFileResponse>>(EndpointRevokeOvpnFile, 
                 request, token, cancellationToken);
-        
-        if (response is { Success: true, Data: not null })
-        {
-            logger.LogInformation("Successfully revoked OVPN file for " +
-                                   $"CommonName: {request.CommonName}, ServerId: {request.VpnServerId}, " +
-                                   $"Response: {response}");
-        }
-        else
-        {
-            logger.LogError("Failed to revoke OVPN file for " +
-                             $"CommonName: {request.CommonName}, ServerId: {request.VpnServerId}, " +
-                             $"Response: {response}");
-        }
 
-        return response!.Data!;
+        return RequireSuccessData(response, "revoke OVPN file");
     }
 }

--- a/DataGateVPNBot/Services/DashboardServices/OvpnFileService.cs
+++ b/DataGateVPNBot/Services/DashboardServices/OvpnFileService.cs
@@ -185,20 +185,7 @@ public class OvpnFileService(
             await httpRequestService.PostAsync<ApiResponse<OvpnFileResponse>>(EndpointAddOpenVpnFile, 
                 request, token, cancellationToken);
 
-        if (response is { Success: true, Data: not null, Data.IssuedOvpnFile.Id: > 0 })
-        {
-        }
-        else
-        {
-            logger.LogWarning($"Failed to get VPN servers: {response?.Message}");
-        }
-
-        if (response == null)
-        {
-            logger.LogError("Failed to fetch Open VPN Servers from API.");
-        }
-
-        return response!.Data!;
+        return RequireSuccessData(response, "create OVPN file");
     }
     
     public async Task<OvpnFileWithTokenResponse> AddOvpnFileWithTokenAsync(AddFileRequest request,
@@ -226,20 +213,20 @@ public class OvpnFileService(
             await httpRequestService.PostAsync<ApiResponse<OvpnFileWithTokenResponse>>(
                 EndpointAddClientOvpnFileWithToken, request, token, cancellationToken);
 
-        if (response is { Success: true, Data: not null, Data.IssuedOvpnFile.Id: > 0 })
-        {
-        }
-        else
-        {
-            logger.LogWarning($"Failed to get VPN servers: {response?.Message}");
-        }
+        return RequireSuccessData(response, "create OVPN file with token");
+    }
 
-        if (response == null)
-        {
-            logger.LogError("Failed to fetch Open VPN Servers from API.");
-        }
+    private T RequireSuccessData<T>(ApiResponse<T>? response, string operation)
+    {
+        if (response is { Success: true, Data: not null })
+            return response.Data;
 
-        return response!.Data!;
+        var message = string.IsNullOrWhiteSpace(response?.Message)
+            ? $"Failed to {operation}."
+            : response.Message;
+
+        logger.LogWarning("Failed to {Operation}: {Message}", operation, message);
+        throw new InvalidOperationException(message);
     }
     
     public async Task<OvpnFileResponse> RevokeOvpnFileAsync(RevokeFileRequest request, 

--- a/DataGateVPNBot/Services/DashboardServices/TelegramBotUserService.cs
+++ b/DataGateVPNBot/Services/DashboardServices/TelegramBotUserService.cs
@@ -1,4 +1,5 @@
 using System.Security.Authentication;
+using DataGateVPNBot.Services.BotServices.Interfaces;
 using DataGateVPNBot.Services.DashboardServices.Interfaces;
 using DataGateVPNBot.Services.Http;
 using DataGateVPNBot.Services.Interfaces;
@@ -14,7 +15,8 @@ public class TelegramBotUserService(
     ILogger<TelegramBotUserService> logger,
     IHttpRequestService httpRequestService,
     AuthService authService,
-    IErrorService errorService)
+    IErrorService errorService,
+    ITelegramProfilePhotoDownloader profilePhotoDownloader)
     : ITelegramBotUserService
 {
     private const string EndpointRegisterUser = "api/users/register-from-tgbot";
@@ -46,12 +48,41 @@ public class TelegramBotUserService(
         {
             var fullName = $"{request.FirstName} {request.LastName}".Trim();
             var displayName = string.IsNullOrWhiteSpace(fullName) ? "Unnamed" : fullName;
+            var username = request.Username?.Trim().TrimStart('@');
+            var usernameLine = string.IsNullOrWhiteSpace(username) ? "@" : $"@{username}";
             var message = $"👤 New user registered:\n" +
                           $"ID: `{request.TelegramId}`\n" +
-                          $"Username: @{request.Username?.Trim().TrimStart('@')}\n" +
+                          $"Username: {usernameLine}\n" +
                           $"Name: {displayName}";
 
-            await errorService.SendMessageToAdminsAsync(message, cancellationToken);
+            byte[]? avatar = null;
+            try
+            {
+                var downloaded = await profilePhotoDownloader.TryDownloadAsync(
+                    request.TelegramId,
+                    cancellationToken);
+                if (downloaded is not null)
+                {
+                    avatar = downloaded.Value.Bytes;
+                    await UpsertProfilePhotoAsync(
+                        new UpsertTelegramBotUserProfilePhotoRequest
+                        {
+                            TelegramId = request.TelegramId,
+                            ProfilePhotoBase64 = Convert.ToBase64String(avatar),
+                            ProfilePhotoMimeType = "image/jpeg",
+                            ProfilePhotoFileUniqueId = downloaded.Value.FileUniqueId
+                        },
+                        cancellationToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Could not fetch profile photo for new user TelegramId {TelegramId}",
+                    request.TelegramId);
+            }
+
+            await errorService.SendPhotoToAdminsAsync(avatar, message, cancellationToken: cancellationToken);
         }
         else
         {

--- a/DataGateVPNBot/Services/DashboardServices/XrayClientLinksDashboardService.cs
+++ b/DataGateVPNBot/Services/DashboardServices/XrayClientLinksDashboardService.cs
@@ -185,20 +185,7 @@ public class XrayClientLinksDashboardService(
             await httpRequestService.PostAsync<ApiResponse<OvpnFileResponse>>(EndpointAdd, 
                 request, token, cancellationToken);
 
-        if (response is { Success: true, Data: not null, Data.IssuedOvpnFile.Id: > 0 })
-        {
-        }
-        else
-        {
-            logger.LogWarning($"Failed to get VPN servers: {response?.Message}");
-        }
-
-        if (response == null)
-        {
-            logger.LogError("Failed to fetch Open VPN Servers from API.");
-        }
-
-        return response!.Data!;
+        return RequireSuccessData(response, "create Xray client link");
     }
     
     public async Task<OvpnFileWithTokenResponse> AddOvpnFileWithTokenAsync(AddFileRequest request,
@@ -226,20 +213,20 @@ public class XrayClientLinksDashboardService(
             await httpRequestService.PostAsync<ApiResponse<OvpnFileWithTokenResponse>>(
                 EndpointAddWithToken, request, token, cancellationToken);
 
-        if (response is { Success: true, Data: not null, Data.IssuedOvpnFile.Id: > 0 })
-        {
-        }
-        else
-        {
-            logger.LogWarning($"Failed to get VPN servers: {response?.Message}");
-        }
+        return RequireSuccessData(response, "create Xray client link with token");
+    }
 
-        if (response == null)
-        {
-            logger.LogError("Failed to fetch Open VPN Servers from API.");
-        }
+    private T RequireSuccessData<T>(ApiResponse<T>? response, string operation)
+    {
+        if (response is { Success: true, Data: not null })
+            return response.Data;
 
-        return response!.Data!;
+        var message = string.IsNullOrWhiteSpace(response?.Message)
+            ? $"Failed to {operation}."
+            : response.Message;
+
+        logger.LogWarning("Failed to {Operation}: {Message}", operation, message);
+        throw new InvalidOperationException(message);
     }
     
     public async Task<OvpnFileResponse> RevokeOvpnFileAsync(RevokeFileRequest request, 
@@ -257,20 +244,7 @@ public class XrayClientLinksDashboardService(
         var response =
             await httpRequestService.PostAsync<ApiResponse<OvpnFileResponse>>(EndpointRevoke, 
                 request, token, cancellationToken);
-        
-        if (response is { Success: true, Data: not null })
-        {
-            logger.LogInformation("Successfully revoked OVPN file for " +
-                                   $"CommonName: {request.CommonName}, ServerId: {request.VpnServerId}, " +
-                                   $"Response: {response}");
-        }
-        else
-        {
-            logger.LogError("Failed to revoke OVPN file for " +
-                             $"CommonName: {request.CommonName}, ServerId: {request.VpnServerId}, " +
-                             $"Response: {response}");
-        }
 
-        return response!.Data!;
+        return RequireSuccessData(response, "revoke Xray client link");
     }
 }

--- a/DataGateVPNBot/Services/ErrorService.cs
+++ b/DataGateVPNBot/Services/ErrorService.cs
@@ -3,6 +3,7 @@ using DataGateVPNBot.Models;
 using DataGateVPNBot.Services.DashboardServices.Interfaces;
 using DataGateVPNBot.Services.Interfaces;
 using Telegram.Bot;
+using Telegram.Bot.Types;
 
 namespace DataGateVPNBot.Services;
 
@@ -65,7 +66,70 @@ public class ErrorService(
         logger.LogInformation("Admins count: {RecordCount}", admins!.TelegramBotAdmins.Count);
         foreach (var admin in admins.TelegramBotAdmins)
         {
-            await botClient.SendMessage(admin.TelegramId, message, cancellationToken: cancellationToken);
+            try
+            {
+                await botClient.SendMessage(admin.TelegramId, message, cancellationToken: cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Failed to send admin message to Telegram ID {TelegramId}.",
+                    admin.TelegramId);
+            }
+        }
+    }
+
+    public async Task SendPhotoToAdminsAsync(
+        byte[]? photoBytes,
+        string caption,
+        string fileName = "avatar.jpg",
+        CancellationToken cancellationToken = default)
+    {
+        if (photoBytes is not { Length: > 0 })
+        {
+            await SendMessageToAdminsAsync(caption, cancellationToken);
+            return;
+        }
+
+        using var scope = serviceProvider.CreateScope();
+        var telegramUsersService = scope.ServiceProvider.GetRequiredService<ITelegramBotUserService>();
+        var botClient = scope.ServiceProvider.GetRequiredService<ITelegramBotClient>();
+        var admins = await telegramUsersService.GetAdminsAsync(cancellationToken);
+
+        if (admins.TelegramBotAdmins is { Count: 0 })
+        {
+            logger.LogWarning("Admin chat ID is not configured.");
+            return;
+        }
+
+        logger.LogInformation("Sending photo alert to {RecordCount} admins.", admins.TelegramBotAdmins.Count);
+        foreach (var admin in admins.TelegramBotAdmins)
+        {
+            try
+            {
+                await using var stream = new MemoryStream(photoBytes, writable: false);
+                await botClient.SendPhoto(
+                    admin.TelegramId,
+                    new InputFileStream(stream, fileName),
+                    caption: caption,
+                    cancellationToken: cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Failed to send admin photo to Telegram ID {TelegramId}; falling back to text.",
+                    admin.TelegramId);
+                try
+                {
+                    await botClient.SendMessage(admin.TelegramId, caption, cancellationToken: cancellationToken);
+                }
+                catch (Exception textEx)
+                {
+                    logger.LogError(textEx,
+                        "Failed to send fallback admin text to Telegram ID {TelegramId}.",
+                        admin.TelegramId);
+                }
+            }
         }
     }
 

--- a/DataGateVPNBot/Services/Http/HttpRequestService.cs
+++ b/DataGateVPNBot/Services/Http/HttpRequestService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using DataGateVPNBot.Services.Interfaces;
@@ -41,6 +42,7 @@ public class HttpRequestService(
         if (response == null || !response.IsSuccessStatusCode)
         {
             logger.LogError("Failed to fetch data from {Url}. StatusCode: {StatusCode}", url, response?.StatusCode);
+            response?.Dispose();
             return default;
         }
 
@@ -48,6 +50,7 @@ public class HttpRequestService(
 
         logger.LogInformation("Received JSON from {Url}: {Json}", url, json);
 
+        response.Dispose();
         return JsonConvert.DeserializeObject<T>(json, JsonSettings);
     }
 
@@ -126,10 +129,31 @@ public class HttpRequestService(
                     errorDetails.AppendLine($"Attempt {attempt}: {response.StatusCode} - {response.ReasonPhrase}");
                     errorDetails.AppendLine($"Response body: {responseContent}");
 
-                    if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                    if (response.StatusCode == HttpStatusCode.Unauthorized)
                     {
                         response.Dispose();
                         return default;
+                    }
+
+                    if (IsNonRetriableClientError(response.StatusCode))
+                    {
+                        if (typeof(T) == typeof(HttpResponseMessage))
+                            return (T)(object)response;
+
+                        T? errorResult = default;
+                        try
+                        {
+                            errorResult = JsonConvert.DeserializeObject<T>(responseContent, JsonSettings);
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogDebug(ex,
+                                "Could not deserialize client-error body from {Url} as {Type}",
+                                url, typeof(T).Name);
+                        }
+
+                        response.Dispose();
+                        return errorResult;
                     }
 
                     response.Dispose();
@@ -149,7 +173,7 @@ public class HttpRequestService(
             }
             catch (OperationCanceledException ex) when (cts.Token.IsCancellationRequested)
             {
-                logger.LogError("Request to {Url} timed out (Attempt {Attempt}) Error: {Error}", 
+                logger.LogError("Request to {Url} timed out (Attempt {Attempt}) Error: {Error}",
                     url, attempt, ex.Message);
                 errorDetails.AppendLine($"Attempt {attempt}: Timeout after {_defaultTimeout.TotalSeconds} seconds.");
                 return default;
@@ -175,4 +199,16 @@ public class HttpRequestService(
         throw exception;
     }
 
+    /// <summary>
+    /// 4xx except timeouts/rate-limits: business/validation errors that must not be retried.
+    /// </summary>
+    private static bool IsNonRetriableClientError(HttpStatusCode statusCode)
+    {
+        var code = (int)statusCode;
+        if (code is < 400 or >= 500)
+            return false;
+
+        return statusCode is not HttpStatusCode.RequestTimeout
+            and not HttpStatusCode.TooManyRequests;
+    }
 }

--- a/DataGateVPNBot/Services/Interfaces/IErrorService.cs
+++ b/DataGateVPNBot/Services/Interfaces/IErrorService.cs
@@ -6,4 +6,14 @@ public interface IErrorService
     Task NotifyAdminsAboutExceptionAsync(Exception exception, HttpContext? context = null, CancellationToken cancellationToken = default);
     Task NotifyAdminsAboutStartAsync(CancellationToken cancellationToken = default);
     Task SendMessageToAdminsAsync(string message, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sends a photo with caption to every bot admin. Falls back to text-only when
+    /// <paramref name="photoBytes"/> is null/empty.
+    /// </summary>
+    Task SendPhotoToAdminsAsync(
+        byte[]? photoBytes,
+        string caption,
+        string fileName = "avatar.jpg",
+        CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- Add unsubscribed VPN users digest command with Email/TG remind buttons.
- Surface keyed dashboard API errors via LocalizationTexts; tighten Free/Default channel-only access copy.
- Registration avatars and SharedModels bumps for digest/remind contracts (through 1.2.3.24).

## Test plan
- [ ] Trigger unsubscribed digest and verify Email + TG remind buttons
- [ ] Confirm channel-only access-denied localization
- [ ] Run telegrambot unit tests for digest/compliance handlers