### PR TITLE
chore: enable GitHub Sponsors (@IMKolganov)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: IMKolganov


### PR DESCRIPTION
## Summary
- Promote `.github/FUNDING.yml` from `develop` so **Sponsor this project** appears on `main` → [@IMKolganov](https://github.com/sponsors/IMKolganov).

## Test plan
- [ ] Sponsor button visible on repository main page
- [ ] Links to https://github.com/sponsors/IMKolganov