### PR TITLE
chore: add Buy Me a Coffee to FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
 # These are supported funding model platforms
 
 github: IMKolganov
+buy_me_a_coffee: imkolganov


### PR DESCRIPTION
## Summary
- Extend `.github/FUNDING.yml` with **Buy Me a Coffee** (`imkolganov`) alongside GitHub Sponsors, so the Sponsor/Funding menu works even when the GitHub Sponsors listing is incomplete.

## Test plan
- [ ] Repo → Sponsor / Funding links show GitHub + Buy Me a Coffee