### PR TITLE
chore: restore FUNDING.yml (Sponsors + Buy Me a Coffee)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,2 @@
-# These are supported funding model platforms
-
-github: IMKolganov
-buy_me_a_coffee: imkolganov
+github: [IMKolganov]
+custom: ["https://buymeacoffee.com/imkolganov"]


### PR DESCRIPTION
## Summary
- Restore `.github/FUNDING.yml` to the working Monitor format: GitHub Sponsors `@IMKolganov` plus custom Buy Me a Coffee link (the previous file only had `github:` and the Sponsor sidebar did not appear on sibling repos).

## Test plan
- [ ] Sidebar shows **Sponsor this project**
- [ ] Links include GitHub Sponsors and buymeacoffee.com/imkolganov